### PR TITLE
Biomeのインストールと設定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "source.removeUnusedImports": "always",
+    "source.sortImports": "explicit",
+    "source.fixAll.biome": "explicit",
+    "source.fixAll.ts": "explicit"
+  },
+  "[javascript][javascriptreact][typescript][typescriptreact][json]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -1,30 +1,56 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-	"vcs": {
-		"enabled": false,
-		"clientKind": "git",
-		"useIgnoreFile": false
-	},
-	"files": {
-		"ignoreUnknown": false,
-		"ignore": []
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab"
-	},
-	"organizeImports": {
-		"enabled": true
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double"
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false,
+    "defaultBranch": "develop"
+  },
+  "files": {
+    "include": ["**/*.ts", "**/*.tsx"],
+    "ignore": ["node_modules", "public", ".next"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "lineWidth": 80,
+    "indentWidth": 2,
+    "attributePosition": "auto"
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noConsoleLog": "error"
+      },
+      "style": {
+        "useSelfClosingElements": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "single",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "all",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto"
+    }
+  },
+  "json": {
+    "parser": { "allowComments": true },
+    "formatter": {
+      "enabled": true,
+      "indentStyle": "space",
+      "lineWidth": 80
+    }
+  }
 }

--- a/frontend/src/app/Dome.tsx
+++ b/frontend/src/app/Dome.tsx
@@ -1,0 +1,5 @@
+const Dome = () => {
+  return <div>Dome</div>
+}
+
+export default Dome

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div>changed</div>;
+  return <div>changed</div>
 }

--- a/node_modules/.bin/biome
+++ b/node_modules/.bin/biome
@@ -1,0 +1,16 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../@biomejs/biome/bin/biome" "$@"
+else 
+  exec node  "$basedir/../@biomejs/biome/bin/biome" "$@"
+fi

--- a/node_modules/.bin/biome.cmd
+++ b/node_modules/.bin/biome.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\@biomejs\biome\bin\biome" %*

--- a/node_modules/.bin/biome.ps1
+++ b/node_modules/.bin/biome.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "$basedir/node$exe"  "$basedir/../@biomejs/biome/bin/biome" $args
+  } else {
+    & "$basedir/node$exe"  "$basedir/../@biomejs/biome/bin/biome" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "node$exe"  "$basedir/../@biomejs/biome/bin/biome" $args
+  } else {
+    & "node$exe"  "$basedir/../@biomejs/biome/bin/biome" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "cinema-reservation-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    }
+  }
+}

--- a/node_modules/@biomejs/biome/LICENSE-APACHE
+++ b/node_modules/@biomejs/biome/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright (c) 2023 Biome Developers and Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/node_modules/@biomejs/biome/LICENSE-MIT
+++ b/node_modules/@biomejs/biome/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Biome Developers and Contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/@biomejs/biome/README.hi.md
+++ b/node_modules/@biomejs/biome/README.hi.md
@@ -1,0 +1,207 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Shows the banner of Biome, with its logo and the phrase 'Biome - Toolchain of the web'." src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![Discord chat][discord-badge]][discord-url]
+[![CI on main][ci-badge]][ci-url]
+[![npm version][npm-badge]][npm-url]
+[![VSCode version][vscode-badge]][vscode-url]
+[![Open VSX version][open-vsx-badge]][open-vsx-url]
+
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=green
+[discord-url]: https://biomejs.dev/chat
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=green&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=green
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=green
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+हिन्दी | [English](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.md) | [繁體中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-TW.md) | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-CN.md) |  [日本語](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.ja.md) | [Português do Brasil](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.pt-br.md) | [한글](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.kr.md)
+
+</div>
+
+
+**Biome** वेब[^1] परियोजना[^2]ओं के लिए एक प्रदर्शनकारी उपकरण-श्रृंखला[^3] है, इसका उद्देश्य उक्त परियोजना[^2]ओं के स्वास्थ्य को बनाए रखने के लिए डेवलपर[^4] उपकरण प्रदान करना है।
+
+**Biome** *JavaScript*, *TypeScript*, *JSX* और *JSON* के लिए **एक [तेज़ स्वरूपक](./benchmark#formatting)[^5]** है जो **[*Prettier* के साथ ९७% अनुकूलता](https://console.algora.io/challenges/prettier)[^6]** स्कोर[^7] करता है।
+
+**Biome *JavaScript*, *TypeScript* और *JSX* के लिए एक [प्रदर्शनकारी लिंटर](https://github.com/biomejs/biome/tree/main/benchmark#linting)[^8]** है जिसमें ESLint, typescript-eslint और [अन्य स्रोतों](https://github.com/biomejs/biome/discussions/3) से **[२७० से अधिक नियम](https://biomejs.dev/linter/rules/)** शामिल हैं। यह **विस्तृत[^9] और संदर्भिकृत[^10] निदान[^11]** आउटपुट[^12] करता है जो आपको अपना कोड[^13] बेहतर बनाने और एक बेहतर प्रोग्रामर[^14] बनने में मदद करता है!
+
+**Biome** को शुरू से ही [संपादक](https://biomejs.dev/guides/integrate-in-editor/)[^15] [के भीतर अंतरक्रियात्मक](https://biomejs.dev/guides/integrate-in-editor/)[^16] [रूप से](https://biomejs.dev/guides/integrate-in-editor/) उपयोग करने के लिए डिज़ाइन[^17] किया गया है। यह आपके द्वारा लिखे जा रहे विकृत[^18] कोड[^13] को स्वरूप[^5] और लिंट[^8] कर सकता है।
+
+### स्थापना[^19]
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### प्रयोग[^20]
+
+* फ़ाइलें[^21] स्वरूप[^5] करें
+
+  ```shell
+  npx @biomejs/biome format --write ./src
+  ```
+
+* फ़ाइलें[^21] लिंट[^8] करें
+
+  ```shell
+  npx @biomejs/biome lint ./src
+  ```
+
+* स्वरूप, लिंट आदि चलाएँ और सुरक्षित सुझाव लागू करें
+
+  ```shell
+  npx @biomejs/biome check --write ./src
+  ```
+
+* CI वातावरण में सभी फ़ाइलों को स्वरूप, लिंट आदि के विरुद्ध जाँचें
+
+  ```shell
+  npx @biomejs/biome ci ./src
+  ```
+
+यदि आप Biome को स्थापित[^19] किए बिना चलाना चाहते हैं, तो WebAssembly में संकलित[^22] [ऑनलाइन](https://biomejs.dev/playground/)[^23] [प्रयोगशाला](https://biomejs.dev/playground/)[^24] का उपयोग करें।
+
+## दस्तावेज़ीकरण[^25]
+
+Biome के बारे में अधिक जानने के लिए हमारे [मुखपृष्ठ][biomejs] पर जाएँ, या Biome का उपयोग शुरू करने के लिए सीधे [आरंभ करने की मार्गदर्शिका][आरंभ-करें][^26] पर जाएँ।
+
+## Biome के बारे में और
+
+**Biome** में उचित पूर्व-निर्धारन[^27] हैं और इसके लिए कॉन्फ़िगरेशन[^28] की आवश्यकता नहीं है।
+
+**Biome** का लक्ष्य आधुनिक वेब[^1] विकास की [सभी मुख्य भाषाओं][भाषा-समर्थन] का समर्थन करना है।
+
+**Biome** को कार्य करने के लिए [Node.js की आवश्यकता नहीं है।](https://biomejs.dev/guides/manual-installation/)
+
+**Biome** में प्रथम-श्रेणी का LSP समर्थन है, जिसमें एक परिष्कृत[^29] पार्सर[^30] है जो स्रोत पाठ[^31] को पूर्ण निष्ठा और शीर्ष-स्तरीय त्रुटि[^32] पुनर्प्राप्ति[^33] में प्रस्तुत करता है।
+
+**Biome** उन कार्यक्षमता[^34]ओं को एकीकृत करता है जो पहले अलग-अलग उपकरण थे। साझा आधार पर निर्माण करने से हमें कोड[^13] प्रोसेसिंग, त्रुटि[^32]यों को प्रदर्शित करने, समानांतर कार्य, कैशिंग[^35] और कॉन्फ़िगरेशन[^28] के लिए एक सुसंगत अनुभव प्रदान करने की अनुमति मिलती है।
+
+हमारे [परियोजना दर्शनशास्र][biome-दर्शनशास्र] के बारे में और पढ़ें।
+
+**Biome** [MIT लाइसेंस प्राप्त](https://github.com/biomejs/biome/tree/main/LICENSE-MIT) या [Apache 2.0 लाइसेंस प्राप्त](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE) है और [योगदानकर्ता अनुबंध आचार संहिता](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md) के तहत संचालित है।
+
+## वित्तपोषण[^36]
+
+आप परियोजना[^2] को विभिन्न तरीकों से वित्तपोषित[^36] कर सकते हैं।
+
+### परियोजना[^2] प्रायोजन[^37] और वित्तपोषण[^36]
+
+आप [Open Collective](https://opencollective.com/biome) या [GitHub Sponsors](https://github.com/sponsors/biomejs) के माध्यम से परियोजना[^2] को प्रायोजित[^37] या वित्तपोषित[^36] कर सकते हैं।
+
+Biome एक सरल प्रायोजन[^37] कार्यक्रम प्रदान करता है जो कंपनियों को विभिन्न डेवलपरों[^4] के बीच दृश्यता[^38] और मान्यता प्राप्त करने की अनुमति देता है।
+
+### वित्तपोषण[^36] जारी करना
+
+हम [Polar.sh](https://polar.sh/biomejs) का उपयोग उन विशिष्ट[^39] सुविधाओं के पक्ष में वोट[^40] करने और बढ़ावा देने के लिए करते हैं जिन्हें आप देखना और लागू करना चाहते हैं। हमारे बकाया कार्य[^41] की जाँच करें और हमारी मदद करें:
+
+[![वित्तपोषण जारी करें](https://polar.sh/embed/fund-our-backlog.svg?org=biomejs)](https://polar.sh/biomejs/)
+
+## प्रायोजक[^37]
+
+### स्वर्ण प्रायोजक[^42]
+
+### रजत प्रायोजक[^43]
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://l2beat.com/" target="_blank"><img src="https://images.opencollective.com/l2beat/c2b2a27/logo/256.png" height="100"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### कांस्य प्रायोजक[^44]
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nanabit.dev/" target="_blank"><img src="https://images.opencollective.com/nanabit/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://vital.io/" target="_blank"><img src="https://avatars.githubusercontent.com/u/25357309?s=200" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://coderabbit.ai/" target="_blank"><img src="https://avatars.githubusercontent.com/u/132028505?s=200&v=4" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/
+[biome-दर्शनशास्र]: https://biomejs.dev/internals/philosophy/
+[भाषा-समर्थन]: https://biomejs.dev/internals/language-support/
+[आरंभ-करें]: https://biomejs.dev/guides/getting-started/
+
+## शब्द सूची
+
+नीचे दिए गए तिरछे शब्द आगत शब्द हैं।
+
+[^1]: *वेब* - web: the internet
+[^2]: परियोजना - project
+[^3]: उपकरण-श्रृंखला - toolchain
+[^4]: *डेव/डेवलपर* - dev/developer
+[^5]: स्वरूप/स्वरूपक - format/foramtter
+[^6]: अनुकूल/अनुकूलता - compatible/compatibility
+[^7]: *स्कोर* - score
+[^8]: *लिंट/लिंटर* - lint/linter
+[^9]: विस्तार/विस्तृत - detail/detailed
+[^10]: संदर्भ/संदर्भिकृत - context/contextualized
+[^11]: निदान - diagnosis
+[^12]: *आउटपुट* - output
+[^13]: *कोड* - code
+[^14]: *प्रोग्रामर* - programmer
+[^15]: संपादक - editor, the text editor: vscode, zed, etc.
+[^16]: अंतरक्रिया/अंतरक्रियात्मक - interact/interactive
+[^17]: *डिज़ाइन* - design
+[^18]: विकृत - malformed
+[^19]: स्थापित_करना/स्थापना - install/installation
+[^20]: प्रयोग - usage
+[^21]: *फ़ाइल* - file
+[^22]: संकलित_करना/संकलित/संकलनकर्ता - compile/compiled/compiler
+[^23]: *ऑनलाइन* - online
+[^24]: प्रयोगशाला - laboratory
+[^25]: दस्तावेज़/दस्तावेज़ीकरण - document/documentation
+[^26]: मार्गदर्शिका - guide
+[^27]: पूर्व-निर्धारित - default
+[^28]: *कॉन्फ़िग/कॉन्फ़िगर/कॉन्फ़िगरेशन* - config/configure/configuration
+[^29]: परिष्कृत - sophisticated
+[^30]: *पार्सर* - parser
+[^31]: पाठ - text
+[^32]: त्रुटि - error
+[^33]: पुनर्प्राप्ति - recovery
+[^34]: कार्यक्षमता - functionality
+[^35]: *कैश/कैशिंग* - cache/caching, ~~cash/cashing~~
+[^36]: वित्तपोषित_करना/वित्तपोषण - fund/funding
+[^37]: प्रायोजित/प्रायोजन - sponsor/sponsorship
+[^38]: दृश्यता - visibility
+[^39]: विशिष्ट - specific
+[^40]: *वोट* - vote
+[^41]: बकाया_कार्य - backlog
+[^42]: स्वर्ण_प्रायोजक - Gold Sponsor
+[^43]: रजत_प्रायोजक - Silver Sponsor
+[^44]: कांस्य_प्रायोजक - Bronze Sponsor

--- a/node_modules/@biomejs/biome/README.ja.md
+++ b/node_modules/@biomejs/biome/README.ja.md
@@ -1,0 +1,115 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Biome - Toolchain of the web" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![Discord chat][discord-badge]][discord-url]
+[![CI on main][ci-badge]][ci-url]
+[![npm version][npm-badge]][npm-url]
+[![VSCode version][vscode-badge]][vscode-url]
+[![Open VSX version][open-vsx-badge]][open-vsx-url]
+
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=green
+[discord-url]: https://biomejs.dev/chat
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=green&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=green
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=green
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+[हिन्दी](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.hi.md) | [English](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.md) | [繁體中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-TW.md) | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-CN.md) | 日本語 | [Português do Brasil](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.pt-br.md) | [한글](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.kr.md)
+
+</div>
+
+
+**Biome** はWebプロジェクトのための高性能なツールチェーンであり、プロジェクトの健全性を維持するための開発者ツールの提供を目的としています。
+
+**Biome は _JavaScript_, _TypeScript_, _JSX_ そして _JSON_ 向けの[高速なFormatter](./benchmark#formatting)**であり、**[_Prettier_ との互換性は97%](https://console.algora.io/challenges/prettier)** を達成しています。
+
+**Biome は _JavaScript_, _TypeScript_, _JSX_ のための[高性能なLinter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** であり、ESLint, typescript-eslint, [その他のソース](https://github.com/biomejs/biome/discussions/3)から **[270以上のルール](https://biomejs.dev/linter/rules/)**を提供しています。Biome は**詳細で文脈に沿った結果を出力**するため、コードを改善し、より良いプログラマになるための手助けをします！
+
+**Biome** は最初から[**エディタ内で対話的に**](https://biomejs.dev/ja/guides/integrate-in-editor/)使用できるように設計されています。
+あなたがコードを書いているときに、形の崩れたコードを format と lint することができます。
+
+### インストール
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### 使い方
+
+```shell
+# ファイルをformatする
+npx @biomejs/biome format --write ./src
+
+# ファイルをlintする
+npx @biomejs/biome lint ./src
+
+# format、lintなどを実行し、安全な提案を適用する
+npx @biomejs/biome check --write ./src
+
+# CI環境では、すべてのファイルを対象にformatやlintをチェックする
+npx @biomejs/biome ci ./src
+```
+
+Biome をインストールせずに試したい場合は、WebAssembly にコンパイルされた[オンラインのプレイグラウンド](https://biomejs.dev/playground/)を利用してください。
+
+## ドキュメント
+
+Biome についてもっと知るために[ホームページ][biomejs]をチェックするか、Biome を使い始めるために[はじめる][getting-started]に進んでください。
+
+## Biome をもっと詳しく
+
+**Biome** は理にかなったデフォルト設定を持ち、設定を必要としません。
+
+**Biome** はモダンなウェブ開発における[全ての主要な言語][language-support]をサポートすることを目指しています。
+
+**Biome** は動作するために Node.js を必要としません。
+
+**Biome** はソーステキストの完全な表現力とエラー回復能力を持つ洗練されたParserによって、優れたLSPサポートを提供します。
+
+**Biome** は以前は別々のツールで提供されていた機能を統合します。共通基盤を構築することで、コードの処理、エラーの表示、並列処理、キャッシュ、設定について統一的な体験を提供します。
+
+興味のある方は、[プロジェクトの理念][biome-philosophy]もご覧ください。
+
+**Biome** は [MIT ライセンス](https://github.com/biomejs/biome/tree/main/LICENSE-MIT)または [Apache 2.0 ライセンス](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE)であり、[コントリビューター行動規範](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md)の下で管理されています。
+
+## スポンサー
+
+### ゴールドスポンサー
+
+### ブロンズスポンサー
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nanabit.dev/" target="_blank"><img src="https://images.opencollective.com/nanabit/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/ja/
+[biome-philosophy]: https://biomejs.dev/ja/internals/philosophy/
+[language-support]: https://biomejs.dev/ja/internals/language-support/
+[getting-started]: https://biomejs.dev/ja/guides/getting-started/

--- a/node_modules/@biomejs/biome/README.kr.md
+++ b/node_modules/@biomejs/biome/README.kr.md
@@ -1,0 +1,158 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Biome - Toolchain of the web" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![Discord chat][discord-badge]][discord-url]
+[![CI on main][ci-badge]][ci-url]
+[![npm version][npm-badge]][npm-url]
+[![VSCode version][vscode-badge]][vscode-url]
+[![Open VSX version][open-vsx-badge]][open-vsx-url]
+
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=green
+[discord-url]: https://biomejs.dev/chat
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=green&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=green
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=green
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+[हिन्दी](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.hi.md) | [English](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.md) | [繁體中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-TW.md) | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-CN.md) | [日本語](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.ja.md) | [Português do Brasil](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.pt-br.md) | 한글
+
+</div>
+
+
+**Biome** 은 웹 프로젝트를 위한 고성능 툴체인으로, 프로젝트를 건전하게 유지하기 위한 개발자 툴을 제공하는 것을 목표로 하고 있습니다.
+
+**Biome** 은 _JavaScript_, _TypeScript_, _JSX_ 그리고 _JSON_ 을 위한 **[고속 Formatter](./benchmark#formatting)** 로, **[_Prettier_ 와의 호환성 97%](https://console.algora.io/challenges/prettier)** 을 달성하고 있습니다.
+
+**Biome** 은 _JavaScript_, _TypeScript_, _JSX_을 위한 **[고성능 Linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** 로、ESLint, typescript-eslint, [등의 리소스](https://github.com/biomejs/biome/discussions/3)에서 **[270개 이상의 룰](https://biomejs.dev/linter/rules/)** 을 제공하고 있습니다. Biome 은 **상세하며 문맥에 맞는 결과를 출력**하기 위해, 코드를 개선하고, 더 좋은 프로그래머가 되기 위한 도움을 드립니다!
+
+**Biome** 은 처음부터 [**에디터 내에서 인터렉티브하게**](https://biomejs.dev/ja/guides/integrate-in-editor/) 사용하도록 설계되어 있습니다.
+여러분이 코드를 작성할 때, 형식이 잘못된 코드에 format, lint 를 적용합니다.
+
+### 설치
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### 사용법
+
+```shell
+# 파일의 format을 체크
+npx @biomejs/biome format --write ./src
+
+# 파일의 lint를 체크
+npx @biomejs/biome lint ./src
+
+# format、lint 등을 실행하고, Biome으로부터의 제안을 적용
+npx @biomejs/biome check --write ./src
+
+# CI 환경에서는 모든 파일을 대상으로 format과 lint를 체크
+npx @biomejs/biome ci ./src
+```
+
+Biome 을 설치하지 않고 사용해보고 싶다면, WebAssembly 에 컴파일된 [온라인 플레이그라운드](https://biomejs.dev/playground/)을 이용해주세요.
+
+## 문서
+
+Biome 에 대해 알아보기 위해 [홈페이지][biomejs]를 체크하거나, Biome 을 사용하기 위해 [시작하기][getting-started]을 확인하세요!
+
+## Biome 를 자세히 알아보기
+
+**Biome** 은 이성적인 디폴트 세팅을 가지고 있어, 설정을 필요로 하지 않습니다.
+
+**Biome** 은 모던한 웹개발에 대한 [모든 주요 언어][language-support]를 지원하는 것을 목표로 합니다.
+
+**Biome** 이 동작하는 데에 Node.js 는 필요하지 않습니다.
+
+**Biome** 은 소스 코드의 완전한 표현력과 에러 회피 능력을 가진, 세련된 Parser 에 의해 우수한 LSP 지원을 제공합니다.
+
+**Biome** 은 지금까지 서로 다른 툴로 제공하던 기능들을 통합합니다. 공통된 기반을 구축하는 것으로 코드 처리, 에러 표시, 병렬 처리, 캐시, 설정에 대해 일관된 경험을 제공합니다.
+
+관심이 있는 분은 [프로젝트 철학][biome-philosophy] 을 확인해주세요.
+
+**Biome** 은 [MIT 라이센스](https://github.com/biomejs/biome/tree/main/LICENSE-MIT) 혹은 [Apache 2.0 라이센스](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE)로, [기여자 행동 규범](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md)에 따라 관리되고 있습니다.
+
+## 펀딩
+
+다양한 방법으로 프로젝트를 지원할 수 있습니다.
+
+### 프로젝트 스폰서와 펀딩
+
+[Open collective](https://opencollective.com/biome) 혹은 [GitHub sponsors](https://github.com/sponsors/biomejs)를 통해 스폰서과 되거나 프로젝트에 지원을 할 수 있습니다.
+
+Biome 은 간단하게 다양한 개발자들 사이에서의 인지도를 얻을 수 있는 스폰서쉽 프로그램을 제공합니다.
+
+### 이슈 펀딩
+
+우리는 투표와 여러분들이 원하는 신기능 추진을 위해 [Polar.sh](https://polar.sh/biomejs)을 사용하고 있습니다. 백로그를 체크하고 지원해주세요!
+
+<a href="https://polar.sh/biomejs"><img src="https://polar.sh/embed/fund-our-backlog.svg?org=biomejs" /></a>
+
+## 후원
+
+### 골드 스폰서
+
+### 실버 스폰서
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://l2beat.com/" target="_blank"><img src="https://images.opencollective.com/l2beat/c2b2a27/logo/256.png" height="100"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://www.phoenixlabs.dev/" target="_blank"><img src="https://images.opencollective.com/phoenix-labs/2824ed4/logo/100.png?height=100" height="100"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### 브론즈 스폰서
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nanabit.dev/" target="_blank"><img src="https://images.opencollective.com/nanabit/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://vital.io/" target="_blank"><img src="https://avatars.githubusercontent.com/u/25357309?s=200" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://coderabbit.ai/" target="_blank"><img src="https://avatars.githubusercontent.com/u/132028505?s=200&v=4" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://forge42.dev/" target="_blank"><img src="https://avatars.githubusercontent.com/u/161314831?s=200&v=4" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://transloadit.com/" target="_blank"><img src="https://avatars.githubusercontent.com/u/125754?s=200&v=4" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/ja/
+[biome-philosophy]: https://biomejs.dev/ja/internals/philosophy/
+[language-support]: https://biomejs.dev/ja/internals/language-support/
+[getting-started]: https://biomejs.dev/ja/guides/getting-started/

--- a/node_modules/@biomejs/biome/README.md
+++ b/node_modules/@biomejs/biome/README.md
@@ -1,0 +1,159 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Shows the banner of Biome, with its logo and the phrase 'Biome - Toolchain of the web'." src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![CI on main][ci-badge]][ci-url]
+[![Discord chat][discord-badge]][discord-url]
+[![npm version][npm-badge]][npm-url]
+[![VSCode version][vscode-badge]][vscode-url]
+[![Open VSX version][open-vsx-badge]][open-vsx-url]
+[![Polar bounties][polar-badge]][polar-url]
+
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=60a5fa
+[discord-url]: https://biomejs.dev/chat
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=60a5fa&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=60a5fa
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=60a5fa
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+[polar-badge]: https://polar.sh/embed/seeks-funding-shield.svg?org=biomejs
+[polar-url]: https://polar.sh/biomejs
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+[हिन्दी](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.hi.md) | English | [繁體中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-TW.md) | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-CN.md) | [日本語](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.ja.md) | [Português do Brasil](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.pt-BR.md) | [한글](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.kr.md)
+
+</div>
+
+**Biome** is a performant toolchain for web projects, it aims to provide developer tools to maintain the health of said projects.
+
+**Biome is a [fast formatter](./benchmark#formatting)** for _JavaScript_, _TypeScript_, _JSX_, _JSON_, _CSS_ and _GraphQL_ that scores **[97% compatibility with _Prettier_](https://console.algora.io/challenges/prettier)**.
+
+**Biome is a [performant linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)** for _JavaScript_, _TypeScript_, _JSX_, _CSS_ and _GraphQL_ that features **[more than 270 rules](https://biomejs.dev/linter/rules/)** from ESLint, typescript-eslint, and [other sources](https://github.com/biomejs/biome/discussions/3).
+It **outputs detailed and contextualized diagnostics** that help you to improve your code and become a better programmer!
+
+**Biome** is designed from the start to be used [interactively within an editor](https://biomejs.dev/guides/integrate-in-editor/).
+It can format and lint malformed code as you are writing it.
+
+### Installation
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### Usage
+
+```shell
+# format files
+npx @biomejs/biome format --write ./src
+
+# lint files and apply the safe fixes
+npx @biomejs/biome lint --write ./src
+
+# run format, lint, etc. and apply the safe fixes
+npx @biomejs/biome check --write ./src
+
+# check all files against format, lint, etc. in CI environments
+npx @biomejs/biome ci ./src
+```
+
+If you want to give Biome a run without installing it, use the [online playground](https://biomejs.dev/playground/), compiled to WebAssembly.
+
+## Documentation
+
+Check out our [homepage][biomejs] to learn more about Biome,
+or directly head to the [Getting Started guide][getting-started] to start using Biome.
+
+## More about Biome
+
+**Biome** has sane defaults and it doesn't require configuration.
+
+**Biome** aims to support [all main languages][language-support] of modern web development.
+
+**Biome** [doesn't require Node.js](https://biomejs.dev/guides/manual-installation/) to function.
+
+**Biome** has first-class LSP support, with a sophisticated parser that represents the source text in full fidelity and top-notch error recovery.
+
+**Biome** unifies functionality that has previously been separate tools. Building upon a shared base allows us to provide a cohesive experience for processing code, displaying errors, parallelize work, caching, and configuration.
+
+Read more about our [project philosophy][biome-philosophy].
+
+**Biome** is [MIT licensed](https://github.com/biomejs/biome/tree/main/LICENSE-MIT) or [Apache 2.0 licensed](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE) and moderated under the [Contributor Covenant Code of Conduct](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md).
+
+## Funding
+
+You can fund the project in different ways
+
+### Project sponsorship and funding
+
+You can sponsor or fund the project via [Open collective](https://opencollective.com/biome) or [GitHub sponsors](https://github.com/sponsors/biomejs)
+
+Biome offers a simple sponsorship program that allows companies to get visibility and recognition among various developers.
+
+### Issue funding
+
+We use [Polar.sh](https://polar.sh/biomejs) to up-vote and promote specific features that you would like to see and implement. Check our backlog and help us:
+
+
+## Sponsors
+
+### Silver Sponsors
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://l2beat.com/" target="_blank"><img src="https://images.opencollective.com/l2beat/c2b2a27/logo/256.png" height="100"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://www.phoenixlabs.dev/" target="_blank"><img src="https://images.opencollective.com/phoenix-labs/2824ed4/logo/100.png?height=100" height="100"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Bronze Sponsors
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nanabit.dev/" target="_blank"><img src="https://images.opencollective.com/nanabit/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://vital.io/" target="_blank"><img src="https://avatars.githubusercontent.com/u/25357309?s=200" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://coderabbit.ai/" target="_blank"><img src="https://avatars.githubusercontent.com/u/132028505?s=200&v=4" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://forge42.dev/" target="_blank"><img src="https://avatars.githubusercontent.com/u/161314831?s=200&v=4" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://transloadit.com/" target="_blank"><img src="https://avatars.githubusercontent.com/u/125754?s=200&v=4" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/
+[biome-philosophy]: https://biomejs.dev/internals/philosophy/
+[language-support]: https://biomejs.dev/internals/language-support/
+[getting-started]: https://biomejs.dev/guides/getting-started/

--- a/node_modules/@biomejs/biome/README.pt-BR.md
+++ b/node_modules/@biomejs/biome/README.pt-BR.md
@@ -1,0 +1,118 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Biome - Conjunto de ferramentas da web" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![Chat no Discord][discord-badge]][discord-url]
+[![CI na `main`][ci-badge]][ci-url]
+[![versão npm][npm-badge]][npm-url]
+[![versão VSCode][vscode-badge]][vscode-url]
+[![versão Open VSX][open-vsx-badge]][open-vsx-url]
+
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=green
+[discord-url]: https://biomejs.dev/chat
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=green&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=green
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=green
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+[हिन्दी](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.hi.md) | [English](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.md) | [繁體中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-TW.md) | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-CN.md) | [日本語](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.ja.md) | Português do Brasil | [한글](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.kr.md)
+
+</div>
+
+**Biome** é um conjunto de ferramentas de alto desempenho para projetos web, visando fornecer recursos de desenvolvimento para manter a saúde desses projetos.
+
+**Biome é um [formatador rápido](./benchmark#formatting)** para _JavaScript_, _TypeScript_, _JSX_, e _JSON_ que atinge **[97% de compatibilidade com o _Prettier_](https://console.algora.io/challenges/prettier)**.
+
+**Biome é um [linter eficiente](https://github.com/biomejs/biome/tree/main/benchmark#linting)** para _JavaScript_, _TypeScript_, e _JSX_ que possui **[mais de 270 regras](https://biomejs.dev/linter/rules/)** do ESLint, typescript-eslint, e de [outras fontes](https://github.com/biomejs/biome/discussions/3).
+Ele **fornece diagnósticos detalhados e contextualizados** que ajudam você a melhorar seu código e se tornar um programador melhor!
+
+**Biome** é projetado desde o início para ser usado [interativamente dentro de um editor](https://biomejs.dev/guides/integrate-in-editor/).
+Isso permite formatar e lintar códigos malformados enquanto você programa.
+
+### Instalação
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### Uso
+
+```shell
+# formatar arquivos
+npx @biomejs/biome format --write ./src
+
+# lintar arquivos
+npx @biomejs/biome lint ./src
+
+# executar formatação, lint, etc. e aplicar as sugestões seguras
+npx @biomejs/biome check --write ./src
+
+# verificar todos os arquivos contra formatação, lint, etc. em ambientes CI
+npx @biomejs/biome ci ./src
+```
+
+Se você quiser experimentar o Biome sem instalá-lo, use o [playground online](https://biomejs.dev/playground/), compilado para WebAssembly.
+
+## Documentação
+
+Confira nossa [página inicial][biomejs] para saber mais sobre o Biome,
+ou vá ao [Guia de Introdução][getting-started] para começar a usar o Biome.
+
+## Mais sobre o Biome
+
+**Biome** tem padrões robustos e não requer configuração.
+
+**Biome** visa suportar [todas as principais linguagens][language-support] do desenvolvimento web moderno.
+
+**Biome** [não requer Node.js](https://biomejs.dev/guides/manual-installation/) para funcionar.
+
+**Biome** tem suporte de primeira linha para LSP, com um
+
+ parser sofisticado que representa o texto-fonte em sua total fidelidade e recuperação de erro de ponta.
+
+**Biome** unifica funcionalidades que anteriormente eram ferramentas separadas. Construindo sobre uma base compartilhada, podemos fornecer uma experiência coesa para processar código, exibir erros, paralelizar trabalho, cache e configuração.
+
+Leia mais sobre nossa [filosofia de projeto][biome-philosophy].
+
+**Biome** é licenciado sob [MIT](https://github.com/biomejs/biome/tree/main/LICENSE-MIT) ou [Apache 2.0](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE) e moderado sob o [Código de Conduta do Contribuidor](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md).
+
+## Patrocinadores
+
+### Patrocinadores Ouro
+
+### Patrocinadores Bronze
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nanabit.dev/" target="_blank"><img src="https://images.opencollective.com/nanabit/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/pt-br/
+[biome-philosophy]: https://biomejs.dev/pt-br/internals/philosophy/
+[language-support]: https://biomejs.dev/pt-br/internals/language-support/
+[getting-started]: https://biomejs.dev/pt-br/guides/getting-started/

--- a/node_modules/@biomejs/biome/README.zh-CN.md
+++ b/node_modules/@biomejs/biome/README.zh-CN.md
@@ -1,0 +1,110 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Biome - Toolchain of the web" src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![Discord chat][discord-badge]][discord-url]
+[![CI on main][ci-badge]][ci-url]
+[![npm version][npm-badge]][npm-url]
+[![VSCode version][vscode-badge]][vscode-url]
+[![Open VSX version][open-vsx-badge]][open-vsx-url]
+
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=green
+[discord-url]: https://biomejs.dev/chat
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=green&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=green
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=green
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+[हिन्दी](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.hi.md) | [English](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.md) | [繁體中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-TW.md) | 简体中文 | [日本語](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.ja.md) | [Português do Brasil](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.pt-br.md) | [한글](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.kr.md)
+
+</div>
+
+**Biome** 是一个用于 Web 项目的高性能工具链，旨在为开发者提供维护项目的工具。
+
+**Biome 是一个[快速的格式化工具](./benchmark#formatting)**，适用于 _JavaScript_、_TypeScript_、_JSX_、_JSON_ 等，与 _Prettier_ 的兼容性达到了 **[97%](https://console.algora.io/challenges/prettier)**。
+
+**Biome 是一个[高性能的 Linter](https://github.com/biomejs/biome/tree/main/benchmark#linting)**，适用于 _JavaScript_、_TypeScript_、_JSX_ 等，包含了来自 ESLint、typescript-eslint 和[其他来源](https://github.com/biomejs/biome/discussions/3)的 **[270 余项规则](https://biomejs.dev/zh-cn/linter/rules/)**。它**输出详细且有上下文诊断信息**，能帮助你优化代码，成为一名更好的程序员！
+
+**Biome** 从一开始就设计为[在编辑器中交互式使用](https://biomejs.dev/zh-cn/guides/integrate-in-editor/)。它可以在你编写代码时格式化并检查出不规范的代码。
+
+### 安装
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### 使用
+
+```shell
+# 格式化文件
+npx @biomejs/biome format --write ./src
+
+# Lint 文件
+npx @biomejs/biome lint ./src
+
+# 运行格式化，Lint 等，并应用安全的建议
+npx @biomejs/biome check --write ./src
+
+# 在 CI 环境中检查所有文件是否符合格式，Lint 等
+npx @biomejs/biome ci ./src
+```
+
+如果你想在不安装的情况下试用 Biome，可以使用[在线 playground](https://biomejs.dev/playground/)，它被编译为 WebAssembly。
+
+## 文档
+
+查看我们的[主页][biomejs]以了解更多关于 Biome 的信息，或者直接前往[入门指南][getting-started]开始使用 Biome。
+
+## 更多信息
+
+**Biome** 有合理的默认设置，不需要配置。
+
+**Biome** 旨在支持[所有主要的现代网络开发语言][language-support]。
+
+**Biome** [不需要 Node.js](https://biomejs.dev/zh-cn/guides/manual-installation/) 就可以运行。
+
+**Biome** 有一流的 LSP 支持，具有精密的解析器，可以完全保真地表示源文本，并具有顶级的错误恢复能力。
+
+**Biome** 统一了以前分散的功能。基于共享的基础，我们可以提供一个处理代码、显示错误、并行工作、缓存和配置的一致体验。
+
+阅读更多关于我们的[项目理念][biome-philosophy]。
+
+**Biome** 采用 [MIT 许可](https://github.com/biomejs/biome/tree/main/LICENSE-MIT) 或 [Apache 2.0 许可](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE)，并在 [贡献者公约行为准则](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md) 下进行管理。
+
+## 赞助商
+
+### 金牌赞助商
+
+### 铜牌赞助商
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/zh-cn/
+[biome-philosophy]: https://biomejs.dev/zh-cn/internals/philosophy/
+[language-support]: https://biomejs.dev/zh-cn/internals/language-support/
+[getting-started]: https://biomejs.dev/zh-cn/guides/getting-started/

--- a/node_modules/@biomejs/biome/README.zh-TW.md
+++ b/node_modules/@biomejs/biome/README.zh-TW.md
@@ -1,0 +1,169 @@
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-dark-transparent.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg">
+        <img alt="Shows the banner of Biome, with its logo and the phrase 'Biome - Toolchain of the web'." src="https://raw.githubusercontent.com/biomejs/resources/main/svg/slogan-light-transparent.svg" width="700">
+    </picture>
+</p>
+
+<div align="center">
+
+[![Discord chat][discord-badge]][discord-url]
+[![CI on main][ci-badge]][ci-url]
+[![npm version][npm-badge]][npm-url]
+[![VSCode version][vscode-badge]][vscode-url]
+[![Open VSX version][open-vsx-badge]][open-vsx-url]
+
+[discord-badge]: https://badgen.net/discord/online-members/BypW39g6Yc?icon=discord&label=discord&color=green
+[discord-url]: https://biomejs.dev/chat
+[ci-badge]: https://github.com/biomejs/biome/actions/workflows/main.yml/badge.svg
+[ci-url]: https://github.com/biomejs/biome/actions/workflows/main.yml
+[npm-badge]: https://badgen.net/npm/v/@biomejs/biome?icon=npm&color=green&label=%40biomejs%2Fbiome
+[npm-url]: https://www.npmjs.com/package/@biomejs/biome/v/latest
+[vscode-badge]: https://badgen.net/vs-marketplace/v/biomejs.biome?label=vscode&icon=visualstudio&color=green
+[vscode-url]: https://marketplace.visualstudio.com/items?itemName=biomejs.biome
+[open-vsx-badge]: https://badgen.net/open-vsx/version/biomejs/biome?label=open-vsx&color=green
+[open-vsx-url]: https://open-vsx.org/extension/biomejs/biome
+
+</div>
+
+<!-- Insert new entries lexicographically by language code.
+     For example given below is the same order as these files appear on page:
+     https://github.com/biomejs/biome/tree/main/packages/%40biomejs/biome -->
+<div align="center">
+
+[हिन्दी](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.hi.md) | [English](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.md) | 繁體中文 | [简体中文](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.zh-CN.md) | [日本語](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.ja.md) | [Português do Brasil](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.pt-BR.md) | [한글](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/README.kr.md)
+
+</div>
+
+**Biome** 是一個高效能的 Web 專案工具鏈，旨在提供開發工具以維持這些專案的健康。
+
+**Biome 是一個 [快速格式化工具](./benchmark#formatting)**，支持 _JavaScript_、_TypeScript_、_JSX_、_JSON_、_CSS_ 和 _GraphQL_，其 **與 _Prettier_ 的相容性達到 [97%](https://console.algora.io/challenges/prettier)**。
+
+**Biome 是一個 [高效能的語法檢查工具](https://github.com/biomejs/biome/tree/main/benchmark#linting)**，支持 _JavaScript_、_TypeScript_、_JSX_、_CSS_ 和 _GraphQL_，擁有來自 ESLint、typescript-eslint 和 [其他來源](https://github.com/biomejs/biome/discussions/3)的 **超過 270 條規則**。
+它 **輸出詳細且具上下文的診斷資訊**，幫助你改進程式碼並成為更好的程式設計師！
+
+**Biome** 從一開始就設計為可在 [編輯器中互動使用](https://biomejs.dev/guides/integrate-in-editor/)。
+它可以在你編寫程式碼時格式化和檢查錯誤的程式碼。
+
+### 安裝
+
+```shell
+npm install --save-dev --save-exact @biomejs/biome
+```
+
+### 使用
+
+```shell
+# 格式化文件
+npx @biomejs/biome format --write ./src
+
+# 檢查文件並應用安全的修正
+npx @biomejs/biome lint --write ./src
+
+# 執行格式化、檢查等並應用安全的修正
+npx @biomejs/biome check --write ./src
+
+# 在 CI 環境中檢查所有文件的格式、檢查等
+npx @biomejs/biome ci ./src
+```
+
+如果你想在不安裝 Biome 的情況下運行它，請使用 [線上 Playground](https://biomejs.dev/playground/)，他被編譯為 WebAssembly。
+
+## 文件
+
+訪問我們的[首頁][biomejs]以了解更多關於 Biome 的資訊，
+或直接前往[入門指南][getting-started]開始使用 Biome。
+
+## 關於 Biome 的更多資訊
+
+**Biome** 擁有合理的預設設定，無需配置。
+
+**Biome** 旨在支持現代 Web 開發的 [所有主要開發語言][language-support]。
+
+**Biome** [不需要 Node.js](https://biomejs.dev/guides/manual-installation/) 即可運行。
+
+**Biome** 擁有一流的 LSP 支持，配備了能完整保留原文的先進解析器和頂級的錯誤修復能力。
+
+**Biome** 整合了以前分離的工具功能。基於共享基礎構建，讓我們能夠為程式碼處理、錯誤顯示、並行工作、快取記憶體和配置提供一致的體驗。
+
+閱讀更多關於我們的[專案理念][biome-philosophy]。
+
+**Biome** 採用 [MIT 授權](https://github.com/biomejs/biome/tree/main/LICENSE-MIT) 或 [Apache 2.0 授權](https://github.com/biomejs/biome/tree/main/LICENSE-APACHE)，並根據 [貢獻者公約行為準則](https://github.com/biomejs/biome/tree/main/CODE_OF_CONDUCT.md) 進行管理。
+
+## 資金支持
+
+你可以通過不同的方式支持這個專案
+
+### 專案贊助和資金支持
+
+你可以通過 [Open Collective](https://opencollective.com/biome) 或 [GitHub Sponsors](https://github.com/sponsors/biomejs) 贊助或資助這個專案。
+
+Biome 提供了一個簡單的贊助計劃，允許公司在各種開發者中獲得可見性和認可。
+
+### 問題資金支持
+
+我們使用 [Polar.sh](https://polar.sh/biomejs) 來提升和推廣你希望看到和實現的特定功能。查看我們的待辦事項並幫助我們：
+
+<a href="https://polar.sh/biomejs"><img src="https://polar.sh/embed/fund-our-backlog.svg?org=biomejs" /></a>
+
+## 贊助商
+
+### 金牌贊助商
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://shiguredo.jp/" target="_blank"><img src="https://shiguredo.jp/official_shiguredo_logo.svg" height="120"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### 銀牌贊助商
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://l2beat.com/" target="_blank"><img src="https://images.opencollective.com/l2beat/c2b2a27/logo/256.png" height="100"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://www.phoenixlabs.dev/" target="_blank"><img src="https://images.opencollective.com/phoenix-labs/2824ed4/logo/100.png?height=100" height="100"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### 銅牌贊助商
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.kanamekey.com" target="_blank"><img src="https://images.opencollective.com/kaname/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nanabit.dev/" target="_blank"><img src="https://images.opencollective.com/nanabit/d15fd98/logo/256.png?height=80" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://vital.io/" target="_blank"><img src="https://avatars.githubusercontent.com/u/25357309?s=200" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://coderabbit.ai/" target="_blank"><img src="https://avatars.githubusercontent.com/u/132028505?s=200&v=4" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://forge42.dev/" target="_blank"><img src="https://avatars.githubusercontent.com/u/161314831?s=200&v=4" width="80"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://transloadit.com/" target="_blank"><img src="https://avatars.githubusercontent.com/u/125754?s=200&v=4" width="80"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+[biomejs]: https://biomejs.dev/
+[biome-philosophy]: https://biomejs.dev/internals/philosophy/
+[language-support]: https://biomejs.dev/internals/language-support/
+[getting-started]: https://biomejs.dev/guides/getting-started/

--- a/node_modules/@biomejs/biome/ROME-LICENSE-MIT
+++ b/node_modules/@biomejs/biome/ROME-LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2023 Rome Tools is Rome Tools, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/@biomejs/biome/bin/biome
+++ b/node_modules/@biomejs/biome/bin/biome
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+const { platform, arch, env, version, release } = process;
+const { execSync } = require("child_process");
+
+function isMusl() {
+	let stderr;
+	try {
+		stderr = execSync("ldd --version", {
+			stdio: ['pipe', 'pipe', 'pipe']
+		});
+	} catch (err) {
+		stderr = err.stderr;
+	}
+	if (stderr.indexOf("musl") > -1) {
+		return true;
+	}
+	return false;
+}
+
+const PLATFORMS = {
+	win32: {
+		x64: "@biomejs/cli-win32-x64/biome.exe",
+		arm64: "@biomejs/cli-win32-arm64/biome.exe",
+	},
+	darwin: {
+		x64: "@biomejs/cli-darwin-x64/biome",
+		arm64: "@biomejs/cli-darwin-arm64/biome",
+	},
+	linux: {
+		x64: "@biomejs/cli-linux-x64/biome",
+		arm64: "@biomejs/cli-linux-arm64/biome",
+	},
+	"linux-musl": {
+		x64: "@biomejs/cli-linux-x64-musl/biome",
+		arm64: "@biomejs/cli-linux-arm64-musl/biome",
+	},
+};
+if (env.ROME_BINARY) {
+	console.warn(`[WARN] The environment variable "ROME_BINARY" is deprecated. Use "BIOME_BINARY" instead.`)
+}
+
+const binPath = env.BIOME_BINARY || env.ROME_BINARY ||
+	(platform === "linux" && isMusl()
+		? PLATFORMS?.["linux-musl"]?.[arch]
+		: PLATFORMS?.[platform]?.[arch]
+	);
+
+if (binPath) {
+	const packageManager = detectPackageManager();
+	const result = require("child_process").spawnSync(
+		require.resolve(binPath),
+		process.argv.slice(2),
+		{
+			shell: false,
+			stdio: "inherit",
+			env: {
+				...env,
+				JS_RUNTIME_VERSION: version,
+				JS_RUNTIME_NAME: release.name,
+				...(packageManager != null
+					? { NODE_PACKAGE_MANAGER: packageManager }
+					: {}),
+			},
+		},
+	);
+
+	if (result.error) {
+		throw result.error;
+	}
+
+	process.exitCode = result.status;
+} else {
+	console.error(
+		"The Biome CLI package doesn't ship with prebuilt binaries for your platform yet. " +
+			"You can still use the CLI by cloning the biome/tools repo from GitHub, " +
+			"and follow the instructions there to build the CLI for your platform.",
+	);
+	process.exitCode = 1;
+}
+
+/**
+ * NPM, Yarn, and other package manager set the `npm_config_user_agent`. It has the following format:
+ *
+ * ```
+ * "npm/8.3.0 node/v16.13.2 win32 x64 workspaces/false
+ * ```
+ *
+ * @returns The package manager string (`npm/8.3.0`) or null if the user agent string isn't set.
+ */
+function detectPackageManager() {
+	const userAgent = env.npm_config_user_agent;
+
+	if (userAgent == null) {
+		return null;
+	}
+
+	return userAgent.split(" ")[0];
+}

--- a/node_modules/@biomejs/biome/configuration_schema.json
+++ b/node_modules/@biomejs/biome/configuration_schema.json
@@ -1,0 +1,4267 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "Configuration",
+	"description": "The configuration that is contained inside the file `biome.json`",
+	"type": "object",
+	"properties": {
+		"$schema": {
+			"description": "A field for the [JSON schema](https://json-schema.org/) specification",
+			"type": ["string", "null"]
+		},
+		"assists": {
+			"description": "Specific configuration for assists",
+			"anyOf": [
+				{ "$ref": "#/definitions/AssistsConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"css": {
+			"description": "Specific configuration for the Css language",
+			"anyOf": [
+				{ "$ref": "#/definitions/CssConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"extends": {
+			"description": "A list of paths to other JSON files, used to extends the current configuration.",
+			"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+		},
+		"files": {
+			"description": "The configuration of the filesystem",
+			"anyOf": [
+				{ "$ref": "#/definitions/FilesConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"formatter": {
+			"description": "The configuration of the formatter",
+			"anyOf": [
+				{ "$ref": "#/definitions/FormatterConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"graphql": {
+			"description": "Specific configuration for the GraphQL language",
+			"anyOf": [
+				{ "$ref": "#/definitions/GraphqlConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"javascript": {
+			"description": "Specific configuration for the JavaScript language",
+			"anyOf": [
+				{ "$ref": "#/definitions/JavascriptConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"json": {
+			"description": "Specific configuration for the Json language",
+			"anyOf": [
+				{ "$ref": "#/definitions/JsonConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"linter": {
+			"description": "The configuration for the linter",
+			"anyOf": [
+				{ "$ref": "#/definitions/LinterConfiguration" },
+				{ "type": "null" }
+			]
+		},
+		"organizeImports": {
+			"description": "The configuration of the import sorting",
+			"anyOf": [{ "$ref": "#/definitions/OrganizeImports" }, { "type": "null" }]
+		},
+		"overrides": {
+			"description": "A list of granular patterns that should be applied only to a sub set of files",
+			"anyOf": [{ "$ref": "#/definitions/Overrides" }, { "type": "null" }]
+		},
+		"vcs": {
+			"description": "The configuration of the VCS integration",
+			"anyOf": [
+				{ "$ref": "#/definitions/VcsConfiguration" },
+				{ "type": "null" }
+			]
+		}
+	},
+	"additionalProperties": false,
+	"definitions": {
+		"A11y": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noAccessKey": {
+					"description": "Enforce that the accessKey attribute is not used on any HTML element.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noAriaHiddenOnFocusable": {
+					"description": "Enforce that aria-hidden=\"true\" is not set on focusable elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noAriaUnsupportedElements": {
+					"description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noAutofocus": {
+					"description": "Enforce that autoFocus prop is not used on elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noBlankTarget": {
+					"description": "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"",
+					"anyOf": [
+						{ "$ref": "#/definitions/AllowDomainConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDistractingElements": {
+					"description": "Enforces that no distracting elements are used.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noHeaderScope": {
+					"description": "The scope prop should be used only on \\<th> elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInteractiveElementToNoninteractiveRole": {
+					"description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noLabelWithoutControl": {
+					"description": "Enforce that a label element or component has a text label and an associated input.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoLabelWithoutControlConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNoninteractiveElementToInteractiveRole": {
+					"description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNoninteractiveTabindex": {
+					"description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noPositiveTabindex": {
+					"description": "Prevent the usage of positive integers on tabIndex property",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRedundantAlt": {
+					"description": "Enforce img alt prop does not contain the word \"image\", \"picture\", or \"photo\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRedundantRoles": {
+					"description": "Enforce explicit role property is not the same as implicit/default role property on an element.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSvgWithoutTitle": {
+					"description": "Enforces the usage of the title element for the svg element.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useAltText": {
+					"description": "Enforce that all elements that require alternative text have meaningful information to relay back to the end user.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useAnchorContent": {
+					"description": "Enforce that anchors have content and that the content is accessible to screen readers.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useAriaActivedescendantWithTabindex": {
+					"description": "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useAriaPropsForRole": {
+					"description": "Enforce that elements with ARIA roles must have all required ARIA attributes for that role.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useButtonType": {
+					"description": "Enforces the usage of the attribute type for the element button",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useFocusableInteractive": {
+					"description": "Elements with an interactive role and interaction handlers must be focusable.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useGenericFontNames": {
+					"description": "Disallow a missing generic family keyword within font families.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useHeadingContent": {
+					"description": "Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useHtmlLang": {
+					"description": "Enforce that html element has lang attribute.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useIframeTitle": {
+					"description": "Enforces the usage of the attribute title for the element iframe.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useKeyWithClickEvents": {
+					"description": "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useKeyWithMouseEvents": {
+					"description": "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useMediaCaption": {
+					"description": "Enforces that audio and video elements must have a track for captions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSemanticElements": {
+					"description": "It detects the use of role attributes in JSX elements and suggests using semantic elements instead.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidAnchor": {
+					"description": "Enforce that all anchors are valid, and they are navigable elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidAriaProps": {
+					"description": "Ensures that ARIA properties aria-* are all valid.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidAriaRole": {
+					"description": "Elements with ARIA roles must use a valid, non-abstract ARIA role.",
+					"anyOf": [
+						{ "$ref": "#/definitions/ValidAriaRoleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidAriaValues": {
+					"description": "Enforce that ARIA state and property values are valid.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidLang": {
+					"description": "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Accessibility": {
+			"type": "string",
+			"enum": ["noPublic", "explicit", "none"]
+		},
+		"Actions": {
+			"type": "object",
+			"properties": {
+				"source": {
+					"anyOf": [{ "$ref": "#/definitions/Source" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"AllowDomainConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithAllowDomainOptions" }
+			]
+		},
+		"AllowDomainOptions": {
+			"type": "object",
+			"properties": {
+				"allowDomains": {
+					"description": "List of domains to allow `target=\"_blank\"` without `rel=\"noreferrer\"`",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"ArrowParentheses": { "type": "string", "enum": ["always", "asNeeded"] },
+		"AssistsConfiguration": {
+			"type": "object",
+			"properties": {
+				"actions": {
+					"description": "Whether Biome should fail in CLI if the assists were not applied to the code.",
+					"anyOf": [{ "$ref": "#/definitions/Actions" }, { "type": "null" }]
+				},
+				"enabled": {
+					"description": "Whether Biome should enable assists via LSP.",
+					"type": ["boolean", "null"]
+				},
+				"ignore": {
+					"description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"include": {
+					"description": "A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"AttributePosition": { "type": "string", "enum": ["auto", "multiline"] },
+		"BracketSpacing": { "type": "boolean" },
+		"Complexity": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noBannedTypes": {
+					"description": "Disallow primitive type aliases and misleading types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEmptyTypeParameters": {
+					"description": "Disallow empty type parameters in type aliases and interfaces.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExcessiveCognitiveComplexity": {
+					"description": "Disallow functions that exceed a given Cognitive Complexity score.",
+					"anyOf": [
+						{ "$ref": "#/definitions/ComplexityConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExcessiveNestedTestSuites": {
+					"description": "This rule enforces a maximum depth to nested describe() in test files.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExtraBooleanCast": {
+					"description": "Disallow unnecessary boolean casts",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noForEach": {
+					"description": "Prefer for...of statement instead of Array.forEach.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMultipleSpacesInRegularExpressionLiterals": {
+					"description": "Disallow unclear usage of consecutive space characters in regular expression literals",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noStaticOnlyClass": {
+					"description": "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noThisInStatic": {
+					"description": "Disallow this and super in static contexts.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessCatch": {
+					"description": "Disallow unnecessary catch clauses.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessConstructor": {
+					"description": "Disallow unnecessary constructors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessEmptyExport": {
+					"description": "Disallow empty exports that don't change anything in a module file.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessFragments": {
+					"description": "Disallow unnecessary fragments",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessLabel": {
+					"description": "Disallow unnecessary labels.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessLoneBlockStatements": {
+					"description": "Disallow unnecessary nested block statements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessRename": {
+					"description": "Disallow renaming import, export, and destructured assignments to the same name.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessStringConcat": {
+					"description": "Disallow unnecessary concatenation of string or template literals.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessSwitchCase": {
+					"description": "Disallow useless case in switch statements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessTernary": {
+					"description": "Disallow ternary operators when simpler alternatives exist.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessThisAlias": {
+					"description": "Disallow useless this aliasing.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessTypeConstraint": {
+					"description": "Disallow using any or unknown as type constraint.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessUndefinedInitialization": {
+					"description": "Disallow initializing variables to undefined.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noVoid": {
+					"description": "Disallow the use of void operators, which is not a familiar operator.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noWith": {
+					"description": "Disallow with statements in non-strict contexts.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useArrowFunction": {
+					"description": "Use arrow functions over function expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useDateNow": {
+					"description": "Use Date.now() to get the number of milliseconds since the Unix Epoch.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useFlatMap": {
+					"description": "Promotes the use of .flatMap() when map().flat() are used together.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useLiteralKeys": {
+					"description": "Enforce the usage of a literal access to properties over computed property access.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useOptionalChain": {
+					"description": "Enforce using concise optional chain instead of chained logical expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useRegexLiterals": {
+					"description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSimpleNumberKeys": {
+					"description": "Disallow number literal object member names which are not base10 or uses underscore as separator",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSimplifiedLogicExpression": {
+					"description": "Discard redundant terms from logical expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ComplexityConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithComplexityOptions" }
+			]
+		},
+		"ComplexityOptions": {
+			"description": "Options for the rule `noExcessiveCognitiveComplexity`.",
+			"type": "object",
+			"properties": {
+				"maxAllowedComplexity": {
+					"description": "The maximum complexity score that we allow. Anything higher is considered excessive.",
+					"default": 15,
+					"type": "integer",
+					"format": "uint8",
+					"minimum": 1.0
+				}
+			},
+			"additionalProperties": false
+		},
+		"ConsistentArrayType": {
+			"oneOf": [
+				{
+					"description": "`ItemType[]`",
+					"type": "string",
+					"enum": ["shorthand"]
+				},
+				{
+					"description": "`Array<ItemType>`",
+					"type": "string",
+					"enum": ["generic"]
+				}
+			]
+		},
+		"ConsistentArrayTypeConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithConsistentArrayTypeOptions" }
+			]
+		},
+		"ConsistentArrayTypeOptions": {
+			"type": "object",
+			"properties": {
+				"syntax": {
+					"default": "shorthand",
+					"allOf": [{ "$ref": "#/definitions/ConsistentArrayType" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ConsistentMemberAccessibilityConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithConsistentMemberAccessibilityOptions" }
+			]
+		},
+		"ConsistentMemberAccessibilityOptions": {
+			"type": "object",
+			"properties": {
+				"accessibility": {
+					"default": "noPublic",
+					"allOf": [{ "$ref": "#/definitions/Accessibility" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Convention": {
+			"type": "object",
+			"properties": {
+				"formats": {
+					"description": "String cases to enforce",
+					"allOf": [{ "$ref": "#/definitions/Formats" }]
+				},
+				"match": {
+					"description": "Regular expression to enforce",
+					"anyOf": [{ "$ref": "#/definitions/Regex" }, { "type": "null" }]
+				},
+				"selector": {
+					"description": "Declarations concerned by this convention",
+					"allOf": [{ "$ref": "#/definitions/Selector" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Correctness": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noChildrenProp": {
+					"description": "Prevent passing of children as props.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConstAssign": {
+					"description": "Prevents from having const variables being re-assigned.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConstantCondition": {
+					"description": "Disallow constant expressions in conditions",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConstantMathMinMaxClamp": {
+					"description": "Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConstructorReturn": {
+					"description": "Disallow returning a value from a constructor.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEmptyCharacterClassInRegex": {
+					"description": "Disallow empty character classes in regular expression literals.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEmptyPattern": {
+					"description": "Disallows empty destructuring patterns.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noFlatMapIdentity": {
+					"description": "Disallow to use unnecessary callback on flatMap.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noGlobalObjectCalls": {
+					"description": "Disallow calling global object properties as functions",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInnerDeclarations": {
+					"description": "Disallow function and var declarations that are accessible outside their block.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidBuiltinInstantiation": {
+					"description": "Ensure that builtins are correctly instantiated.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidConstructorSuper": {
+					"description": "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidDirectionInLinearGradient": {
+					"description": "Disallow non-standard direction values for linear gradient functions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidGridAreas": {
+					"description": "Disallows invalid named grid areas in CSS Grid Layouts.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidNewBuiltin": {
+					"description": "Disallow new operators with global non-constructor functions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidPositionAtImportRule": {
+					"description": "Disallow the use of @import at-rules in invalid positions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInvalidUseBeforeDeclaration": {
+					"description": "Disallow the use of variables and function parameters before their declaration",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNewSymbol": {
+					"description": "Disallow new operators with the Symbol object.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNodejsModules": {
+					"description": "Forbid the use of Node.js builtin modules.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNonoctalDecimalEscape": {
+					"description": "Disallow \\8 and \\9 escape sequences in string literals.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noPrecisionLoss": {
+					"description": "Disallow literal numbers that lose precision",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRenderReturnValue": {
+					"description": "Prevent the usage of the return value of React.render.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSelfAssign": {
+					"description": "Disallow assignments where both sides are exactly the same.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSetterReturn": {
+					"description": "Disallow returning a value from a setter",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noStringCaseMismatch": {
+					"description": "Disallow comparison of expressions modifying the string case with non-compliant value.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSwitchDeclarations": {
+					"description": "Disallow lexical declarations in switch clauses.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUndeclaredDependencies": {
+					"description": "Disallow the use of dependencies that aren't specified in the package.json.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUndeclaredVariables": {
+					"description": "Prevents the usage of variables that haven't been declared inside the document.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownFunction": {
+					"description": "Disallow unknown CSS value functions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownMediaFeatureName": {
+					"description": "Disallow unknown media feature names.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownProperty": {
+					"description": "Disallow unknown properties.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownUnit": {
+					"description": "Disallow unknown CSS units.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnmatchableAnbSelector": {
+					"description": "Disallow unmatchable An+B selectors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnnecessaryContinue": {
+					"description": "Avoid using unnecessary continue.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnreachable": {
+					"description": "Disallow unreachable code",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnreachableSuper": {
+					"description": "Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnsafeFinally": {
+					"description": "Disallow control flow statements in finally blocks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnsafeOptionalChaining": {
+					"description": "Disallow the use of optional chaining in contexts where the undefined value is not allowed.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnusedFunctionParameters": {
+					"description": "Disallow unused function parameters.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnusedImports": {
+					"description": "Disallow unused imports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnusedLabels": {
+					"description": "Disallow unused labels.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnusedPrivateClassMembers": {
+					"description": "Disallow unused private class members",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnusedVariables": {
+					"description": "Disallow unused variables.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noVoidElementsWithChildren": {
+					"description": "This rules prevents void elements (AKA self-closing elements) from having children.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noVoidTypeReturn": {
+					"description": "Disallow returning a value from a function with the return type 'void'",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useArrayLiterals": {
+					"description": "Disallow Array constructors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useExhaustiveDependencies": {
+					"description": "Enforce all dependencies are correctly specified in a React hook.",
+					"anyOf": [
+						{ "$ref": "#/definitions/UseExhaustiveDependenciesConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useHookAtTopLevel": {
+					"description": "Enforce that all React hooks are being called from the Top Level component functions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/DeprecatedHooksConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useImportExtensions": {
+					"description": "Enforce file extensions for relative imports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/UseImportExtensionsConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useIsNan": {
+					"description": "Require calls to isNaN() when checking for NaN.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useJsxKeyInIterable": {
+					"description": "Disallow missing key props in iterators/collection literals.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidForDirection": {
+					"description": "Enforce \"for\" loop update clause moving the counter in the right direction.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useYield": {
+					"description": "Require generator functions to contain yield.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CssAssists": {
+			"description": "Options that changes how the CSS assists behaves",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the assists for CSS files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CssConfiguration": {
+			"description": "Options applied to CSS files",
+			"type": "object",
+			"properties": {
+				"assists": {
+					"description": "CSS assists options",
+					"anyOf": [{ "$ref": "#/definitions/CssAssists" }, { "type": "null" }]
+				},
+				"formatter": {
+					"description": "CSS formatter options",
+					"anyOf": [
+						{ "$ref": "#/definitions/CssFormatter" },
+						{ "type": "null" }
+					]
+				},
+				"linter": {
+					"description": "CSS linter options",
+					"anyOf": [{ "$ref": "#/definitions/CssLinter" }, { "type": "null" }]
+				},
+				"parser": {
+					"description": "CSS parsing options",
+					"anyOf": [{ "$ref": "#/definitions/CssParser" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CssFormatter": {
+			"description": "Options that changes how the CSS formatter behaves",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the formatter for CSS (and its super languages) files.",
+					"type": ["boolean", "null"]
+				},
+				"indentStyle": {
+					"description": "The indent style applied to CSS (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation applied to CSS (and its super languages) files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending applied to CSS (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line applied to CSS (and its super languages) files. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"quoteStyle": {
+					"description": "The type of quotes used in CSS code. Defaults to double.",
+					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CssLinter": {
+			"description": "Options that changes how the CSS linter behaves",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for CSS files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CssParser": {
+			"description": "Options that changes how the CSS parser behaves",
+			"type": "object",
+			"properties": {
+				"allowWrongLineComments": {
+					"description": "Allow comments to appear on incorrect lines in `.css` files",
+					"type": ["boolean", "null"]
+				},
+				"cssModules": {
+					"description": "Enables parsing of CSS Modules specific features.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"CustomRestrictedType": {
+			"anyOf": [
+				{ "type": "string" },
+				{ "$ref": "#/definitions/CustomRestrictedTypeOptions" }
+			]
+		},
+		"CustomRestrictedTypeOptions": {
+			"type": "object",
+			"properties": {
+				"message": { "default": "", "type": "string" },
+				"use": { "default": null, "type": ["string", "null"] }
+			},
+			"additionalProperties": false
+		},
+		"DeprecatedHooksConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithDeprecatedHooksOptions" }
+			]
+		},
+		"DeprecatedHooksOptions": {
+			"description": "Options for the `useHookAtTopLevel` rule have been deprecated, since we now use the React hook naming convention to determine whether a function is a hook.",
+			"type": "object",
+			"additionalProperties": false
+		},
+		"FilenameCase": {
+			"description": "Supported cases for file names.",
+			"oneOf": [
+				{ "description": "camelCase", "type": "string", "enum": ["camelCase"] },
+				{
+					"description": "Match an export name",
+					"type": "string",
+					"enum": ["export"]
+				},
+				{
+					"description": "kebab-case",
+					"type": "string",
+					"enum": ["kebab-case"]
+				},
+				{
+					"description": "PascalCase",
+					"type": "string",
+					"enum": ["PascalCase"]
+				},
+				{
+					"description": "snake_case",
+					"type": "string",
+					"enum": ["snake_case"]
+				}
+			]
+		},
+		"FilenameCases": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/FilenameCase" },
+			"uniqueItems": true
+		},
+		"FilenamingConventionConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithFilenamingConventionOptions" }
+			]
+		},
+		"FilenamingConventionOptions": {
+			"description": "Rule's options.",
+			"type": "object",
+			"properties": {
+				"filenameCases": {
+					"description": "Allowed cases for file names.",
+					"allOf": [{ "$ref": "#/definitions/FilenameCases" }]
+				},
+				"requireAscii": {
+					"description": "If `false`, then non-ASCII characters are allowed.",
+					"type": "boolean"
+				},
+				"strictCase": {
+					"description": "If `false`, then consecutive uppercase are allowed in _camel_ and _pascal_ cases. This does not affect other [Case].",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"FilesConfiguration": {
+			"description": "The configuration of the filesystem",
+			"type": "object",
+			"properties": {
+				"ignore": {
+					"description": "A list of Unix shell style patterns. Biome will ignore files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"ignoreUnknown": {
+					"description": "Tells Biome to not emit diagnostics when handling files that doesn't know",
+					"type": ["boolean", "null"]
+				},
+				"include": {
+					"description": "A list of Unix shell style patterns. Biome will handle only those files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"maxSize": {
+					"description": "The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB",
+					"type": ["integer", "null"],
+					"format": "uint64",
+					"minimum": 1.0
+				}
+			},
+			"additionalProperties": false
+		},
+		"FixKind": {
+			"description": "Used to identify the kind of code action emitted by a rule",
+			"oneOf": [
+				{
+					"description": "The rule doesn't emit code actions.",
+					"type": "string",
+					"enum": ["none"]
+				},
+				{
+					"description": "The rule emits a code action that is safe to apply. Usually these fixes don't change the semantic of the program.",
+					"type": "string",
+					"enum": ["safe"]
+				},
+				{
+					"description": "The rule emits a code action that is _unsafe_ to apply. Usually these fixes remove comments, or change the semantic of the program.",
+					"type": "string",
+					"enum": ["unsafe"]
+				}
+			]
+		},
+		"Format": {
+			"description": "Supported cases.",
+			"type": "string",
+			"enum": ["camelCase", "CONSTANT_CASE", "PascalCase", "snake_case"]
+		},
+		"Formats": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/Format" },
+			"uniqueItems": true
+		},
+		"FormatterConfiguration": {
+			"description": "Generic options applied to all files",
+			"type": "object",
+			"properties": {
+				"attributePosition": {
+					"description": "The attribute position style in HTMLish languages. By default auto.",
+					"anyOf": [
+						{ "$ref": "#/definitions/AttributePosition" },
+						{ "type": "null" }
+					]
+				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
+				"enabled": { "type": ["boolean", "null"] },
+				"formatWithErrors": {
+					"description": "Stores whether formatting should be allowed to proceed if a given file has syntax errors",
+					"type": ["boolean", "null"]
+				},
+				"ignore": {
+					"description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"include": {
+					"description": "A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"indentSize": {
+					"description": "The size of the indentation, 2 by default (deprecated, use `indent-width`)",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"indentStyle": {
+					"description": "The indent style.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation, 2 by default",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"useEditorconfig": {
+					"description": "Use any `.editorconfig` files to configure the formatter. Configuration in `biome.json` will override `.editorconfig` configuration. Default: false.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"GraphqlConfiguration": {
+			"description": "Options applied to GraphQL files",
+			"type": "object",
+			"properties": {
+				"formatter": {
+					"description": "GraphQL formatter options",
+					"anyOf": [
+						{ "$ref": "#/definitions/GraphqlFormatter" },
+						{ "type": "null" }
+					]
+				},
+				"linter": {
+					"anyOf": [
+						{ "$ref": "#/definitions/GraphqlLinter" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"GraphqlFormatter": {
+			"description": "Options that changes how the GraphQL formatter behaves",
+			"type": "object",
+			"properties": {
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
+				"enabled": {
+					"description": "Control the formatter for GraphQL files.",
+					"type": ["boolean", "null"]
+				},
+				"indentStyle": {
+					"description": "The indent style applied to GraphQL files.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation applied to GraphQL files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending applied to GraphQL files.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line applied to GraphQL files. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"quoteStyle": {
+					"description": "The type of quotes used in GraphQL code. Defaults to double.",
+					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"GraphqlLinter": {
+			"description": "Options that changes how the GraphQL linter behaves",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the formatter for GraphQL files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Hook": {
+			"type": "object",
+			"properties": {
+				"closureIndex": {
+					"description": "The \"position\" of the closure function, starting from zero.\n\nFor example, for React's `useEffect()` hook, the closure index is 0.",
+					"default": null,
+					"type": ["integer", "null"],
+					"format": "uint8",
+					"minimum": 0.0
+				},
+				"dependenciesIndex": {
+					"description": "The \"position\" of the array of dependencies, starting from zero.\n\nFor example, for React's `useEffect()` hook, the dependencies index is 1.",
+					"default": null,
+					"type": ["integer", "null"],
+					"format": "uint8",
+					"minimum": 0.0
+				},
+				"name": {
+					"description": "The name of the hook.",
+					"default": "",
+					"type": "string"
+				},
+				"stableResult": {
+					"description": "Whether the result of the hook is stable.\n\nSet to `true` to mark the identity of the hook's return value as stable, or use a number/an array of numbers to mark the \"positions\" in the return array as stable.\n\nFor example, for React's `useRef()` hook the value would be `true`, while for `useState()` it would be `[1]`.",
+					"default": null,
+					"anyOf": [
+						{ "$ref": "#/definitions/StableHookResult" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"IndentStyle": {
+			"oneOf": [
+				{ "description": "Tab", "type": "string", "enum": ["tab"] },
+				{ "description": "Space", "type": "string", "enum": ["space"] }
+			]
+		},
+		"IndentWidth": { "type": "integer", "format": "uint8", "minimum": 0.0 },
+		"JavascriptAssists": {
+			"description": "Linter options specific to the JavaScript linter",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for JavaScript (and its super languages) files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JavascriptConfiguration": {
+			"description": "A set of options applied to the JavaScript files",
+			"type": "object",
+			"properties": {
+				"assists": {
+					"description": "Assists options",
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptAssists" },
+						{ "type": "null" }
+					]
+				},
+				"formatter": {
+					"description": "Formatting options",
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptFormatter" },
+						{ "type": "null" }
+					]
+				},
+				"globals": {
+					"description": "A list of global bindings that should be ignored by the analyzers\n\nIf defined here, they should not emit diagnostics.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"jsxRuntime": {
+					"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
+					"anyOf": [{ "$ref": "#/definitions/JsxRuntime" }, { "type": "null" }]
+				},
+				"linter": {
+					"description": "Linter options",
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptLinter" },
+						{ "type": "null" }
+					]
+				},
+				"organizeImports": {
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptOrganizeImports" },
+						{ "type": "null" }
+					]
+				},
+				"parser": {
+					"description": "Parsing options",
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptParser" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JavascriptFormatter": {
+			"description": "Formatting options specific to the JavaScript files",
+			"type": "object",
+			"properties": {
+				"arrowParentheses": {
+					"description": "Whether to add non-necessary parentheses to arrow functions. Defaults to \"always\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/ArrowParentheses" },
+						{ "type": "null" }
+					]
+				},
+				"attributePosition": {
+					"description": "The attribute position style in jsx elements. Defaults to auto.",
+					"anyOf": [
+						{ "$ref": "#/definitions/AttributePosition" },
+						{ "type": "null" }
+					]
+				},
+				"bracketSameLine": {
+					"description": "Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.",
+					"type": ["boolean", "null"]
+				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
+				"enabled": {
+					"description": "Control the formatter for JavaScript (and its super languages) files.",
+					"type": ["boolean", "null"]
+				},
+				"indentSize": {
+					"description": "The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"indentStyle": {
+					"description": "The indent style applied to JavaScript (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"jsxQuoteStyle": {
+					"description": "The type of quotes used in JSX. Defaults to double.",
+					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending applied to JavaScript (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line applied to JavaScript (and its super languages) files. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"quoteProperties": {
+					"description": "When properties in objects are quoted. Defaults to asNeeded.",
+					"anyOf": [
+						{ "$ref": "#/definitions/QuoteProperties" },
+						{ "type": "null" }
+					]
+				},
+				"quoteStyle": {
+					"description": "The type of quotes used in JavaScript code. Defaults to double.",
+					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
+				},
+				"semicolons": {
+					"description": "Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.",
+					"anyOf": [{ "$ref": "#/definitions/Semicolons" }, { "type": "null" }]
+				},
+				"trailingComma": {
+					"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/TrailingCommas" },
+						{ "type": "null" }
+					]
+				},
+				"trailingCommas": {
+					"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/TrailingCommas" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JavascriptLinter": {
+			"description": "Linter options specific to the JavaScript linter",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for JavaScript (and its super languages) files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JavascriptOrganizeImports": {
+			"type": "object",
+			"additionalProperties": false
+		},
+		"JavascriptParser": {
+			"description": "Options that changes how the JavaScript parser behaves",
+			"type": "object",
+			"properties": {
+				"unsafeParameterDecoratorsEnabled": {
+					"description": "It enables the experimental and unsafe parsing of parameter decorators\n\nThese decorators belong to an old proposal, and they are subject to change.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsonAssists": {
+			"description": "Linter options specific to the JSON linter",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for JSON (and its super languages) files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsonConfiguration": {
+			"description": "Options applied to JSON files",
+			"type": "object",
+			"properties": {
+				"assists": {
+					"description": "Assists options",
+					"anyOf": [{ "$ref": "#/definitions/JsonAssists" }, { "type": "null" }]
+				},
+				"formatter": {
+					"description": "Formatting options",
+					"anyOf": [
+						{ "$ref": "#/definitions/JsonFormatter" },
+						{ "type": "null" }
+					]
+				},
+				"linter": {
+					"description": "Linting options",
+					"anyOf": [{ "$ref": "#/definitions/JsonLinter" }, { "type": "null" }]
+				},
+				"parser": {
+					"description": "Parsing options",
+					"anyOf": [{ "$ref": "#/definitions/JsonParser" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsonFormatter": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the formatter for JSON (and its super languages) files.",
+					"type": ["boolean", "null"]
+				},
+				"indentSize": {
+					"description": "The size of the indentation applied to JSON (and its super languages) files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"indentStyle": {
+					"description": "The indent style applied to JSON (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation applied to JSON (and its super languages) files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending applied to JSON (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line applied to JSON (and its super languages) files. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"trailingCommas": {
+					"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"none\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/TrailingCommas2" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsonLinter": {
+			"description": "Linter options specific to the JSON linter",
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Control the linter for JSON (and its super languages) files.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsonParser": {
+			"description": "Options that changes how the JSON parser behaves",
+			"type": "object",
+			"properties": {
+				"allowComments": {
+					"description": "Allow parsing comments in `.json` files",
+					"type": ["boolean", "null"]
+				},
+				"allowTrailingCommas": {
+					"description": "Allow parsing trailing commas in `.json` files",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"JsxRuntime": {
+			"description": "Indicates the type of runtime or transformation used for interpreting JSX.",
+			"oneOf": [
+				{
+					"description": "Indicates a modern or native JSX environment, that doesn't require special handling by Biome.",
+					"type": "string",
+					"enum": ["transparent"]
+				},
+				{
+					"description": "Indicates a classic React environment that requires the `React` import.\n\nCorresponds to the `react` value for the `jsx` option in TypeScript's `tsconfig.json`.\n\nThis option should only be necessary if you cannot upgrade to a React version that supports the new JSX runtime. For more information about the old vs. new JSX runtime, please see: <https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html>",
+					"type": "string",
+					"enum": ["reactClassic"]
+				}
+			]
+		},
+		"Kind": {
+			"oneOf": [
+				{
+					"type": "string",
+					"enum": [
+						"class",
+						"enum",
+						"interface",
+						"enumMember",
+						"importNamespace",
+						"exportNamespace",
+						"variable",
+						"const",
+						"let",
+						"using",
+						"var",
+						"catchParameter",
+						"indexParameter",
+						"exportAlias",
+						"importAlias",
+						"classGetter",
+						"classSetter",
+						"classMethod",
+						"objectLiteralProperty",
+						"objectLiteralGetter",
+						"objectLiteralSetter",
+						"objectLiteralMethod",
+						"typeAlias"
+					]
+				},
+				{ "description": "All kinds", "type": "string", "enum": ["any"] },
+				{
+					"description": "All type definitions: classes, enums, interfaces, and type aliases",
+					"type": "string",
+					"enum": ["typeLike"]
+				},
+				{
+					"description": "Named function declarations and expressions",
+					"type": "string",
+					"enum": ["function"]
+				},
+				{
+					"description": "TypeScript namespaces, import and export namespaces",
+					"type": "string",
+					"enum": ["namespaceLike"]
+				},
+				{
+					"description": "TypeScript mamespaces",
+					"type": "string",
+					"enum": ["namespace"]
+				},
+				{
+					"description": "All function parameters, but parameter properties",
+					"type": "string",
+					"enum": ["functionParameter"]
+				},
+				{
+					"description": "All generic type parameters",
+					"type": "string",
+					"enum": ["typeParameter"]
+				},
+				{
+					"description": "All class members: properties, methods, getters, and setters",
+					"type": "string",
+					"enum": ["classMember"]
+				},
+				{
+					"description": "All class properties, including parameter properties",
+					"type": "string",
+					"enum": ["classProperty"]
+				},
+				{
+					"description": "All object literal members: properties, methods, getters, and setters",
+					"type": "string",
+					"enum": ["objectLiteralMember"]
+				},
+				{
+					"description": "All members defined in type alaises and interfaces",
+					"type": "string",
+					"enum": ["typeMember"]
+				},
+				{
+					"description": "All getters defined in type alaises and interfaces",
+					"type": "string",
+					"enum": ["typeGetter"]
+				},
+				{
+					"description": "All properties defined in type alaises and interfaces",
+					"type": "string",
+					"enum": ["typeProperty"]
+				},
+				{
+					"description": "All setters defined in type alaises and interfaces",
+					"type": "string",
+					"enum": ["typeSetter"]
+				},
+				{
+					"description": "All methods defined in type alaises and interfaces",
+					"type": "string",
+					"enum": ["typeMethod"]
+				}
+			]
+		},
+		"LineEnding": {
+			"oneOf": [
+				{
+					"description": "Line Feed only (\\n), common on Linux and macOS as well as inside git repos",
+					"type": "string",
+					"enum": ["lf"]
+				},
+				{
+					"description": "Carriage Return + Line Feed characters (\\r\\n), common on Windows",
+					"type": "string",
+					"enum": ["crlf"]
+				},
+				{
+					"description": "Carriage Return character only (\\r), used very rarely",
+					"type": "string",
+					"enum": ["cr"]
+				}
+			]
+		},
+		"LineWidth": {
+			"description": "Validated value for the `line_width` formatter options\n\nThe allowed range of values is 1..=320",
+			"type": "integer",
+			"format": "uint16",
+			"minimum": 0.0
+		},
+		"LinterConfiguration": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "if `false`, it disables the feature and the linter won't be executed. `true` by default",
+					"type": ["boolean", "null"]
+				},
+				"ignore": {
+					"description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"include": {
+					"description": "A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"rules": {
+					"description": "List of rules",
+					"anyOf": [{ "$ref": "#/definitions/Rules" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Modifiers": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/RestrictedModifier" },
+			"uniqueItems": true
+		},
+		"NamingConventionConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNamingConventionOptions" }
+			]
+		},
+		"NamingConventionOptions": {
+			"description": "Rule's options.",
+			"type": "object",
+			"properties": {
+				"conventions": {
+					"description": "Custom conventions.",
+					"type": "array",
+					"items": { "$ref": "#/definitions/Convention" }
+				},
+				"enumMemberCase": {
+					"description": "Allowed cases for _TypeScript_ `enum` member names.",
+					"allOf": [{ "$ref": "#/definitions/Format" }]
+				},
+				"requireAscii": {
+					"description": "If `false`, then non-ASCII characters are allowed.",
+					"type": "boolean"
+				},
+				"strictCase": {
+					"description": "If `false`, then consecutive uppercase are allowed in _camel_ and _pascal_ cases. This does not affect other [Case].",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"NoConsoleConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoConsoleOptions" }
+			]
+		},
+		"NoConsoleOptions": {
+			"type": "object",
+			"required": ["allow"],
+			"properties": {
+				"allow": {
+					"description": "Allowed calls on the console object.",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"NoDoubleEqualsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoDoubleEqualsOptions" }
+			]
+		},
+		"NoDoubleEqualsOptions": {
+			"description": "Rule's options",
+			"type": "object",
+			"properties": {
+				"ignoreNull": {
+					"description": "If `true`, an exception is made when comparing with `null`, as it's often relied on to check both for `null` or `undefined`.\n\nIf `false`, no such exception will be made.",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"NoLabelWithoutControlConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoLabelWithoutControlOptions" }
+			]
+		},
+		"NoLabelWithoutControlOptions": {
+			"type": "object",
+			"properties": {
+				"inputComponents": {
+					"description": "Array of component names that should be considered the same as an `input` element.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"labelAttributes": {
+					"description": "Array of attributes that should be treated as the `label` accessible text content.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"labelComponents": {
+					"description": "Array of component names that should be considered the same as a `label` element.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"NoRestrictedTypesConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoRestrictedTypesOptions" }
+			]
+		},
+		"NoRestrictedTypesOptions": {
+			"type": "object",
+			"properties": {
+				"types": {
+					"default": {},
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/CustomRestrictedType"
+					}
+				}
+			},
+			"additionalProperties": false
+		},
+		"NoSecretsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoSecretsOptions" }
+			]
+		},
+		"NoSecretsOptions": {
+			"type": "object",
+			"properties": {
+				"entropyThreshold": {
+					"description": "Set entropy threshold (default is 41).",
+					"type": ["integer", "null"],
+					"format": "uint16",
+					"minimum": 0.0
+				}
+			},
+			"additionalProperties": false
+		},
+		"Nursery": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noCommonJs": {
+					"description": "Disallow use of CommonJs module system in favor of ESM style imports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDescendingSpecificity": {
+					"description": "Disallow a lower specificity selector from coming after a higher specificity selector.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDocumentCookie": {
+					"description": "Disallow direct assignments to document.cookie.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDocumentImportInPage": {
+					"description": "Prevents importing next/document outside of pages/_document.jsx in Next.js projects.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateCustomProperties": {
+					"description": "Disallow duplicate custom properties within declaration blocks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateElseIf": {
+					"description": "Disallow duplicate conditions in if-else-if chains",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateProperties": {
+					"description": "Disallow duplicate properties within declaration blocks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicatedFields": {
+					"description": "No duplicated fields in GraphQL operations.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDynamicNamespaceImportAccess": {
+					"description": "Disallow accessing namespace imports dynamically.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEnum": {
+					"description": "Disallow TypeScript enum.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExportedImports": {
+					"description": "Disallow exporting an imported variable.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noHeadElement": {
+					"description": "Prevent usage of \\<head> element in a Next.js project.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noHeadImportInDocument": {
+					"description": "Prevent using the next/head module in pages/_document.js on Next.js projects.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noImgElement": {
+					"description": "Prevent usage of \\<img> element in a Next.js project.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noIrregularWhitespace": {
+					"description": "Disallows the use of irregular whitespace characters.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMissingVarFunction": {
+					"description": "Disallow missing var function for css variables.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNestedTernary": {
+					"description": "Disallow nested ternary expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noOctalEscape": {
+					"description": "Disallow octal escape sequences in string literals",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noProcessEnv": {
+					"description": "Disallow the use of process.env.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRestrictedImports": {
+					"description": "Disallow specified modules when loaded by import or require.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RestrictedImportsConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRestrictedTypes": {
+					"description": "Disallow user defined types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoRestrictedTypesConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSecrets": {
+					"description": "Disallow usage of sensitive data such as API keys and tokens.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoSecretsConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noStaticElementInteractions": {
+					"description": "Enforce that static, visible elements (such as \\<div>) that have click handlers use the valid role attribute.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSubstr": {
+					"description": "Enforce the use of String.slice() over String.substr() and String.substring().",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noTemplateCurlyInString": {
+					"description": "Disallow template literal placeholder syntax in regular strings.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownPseudoClass": {
+					"description": "Disallow unknown pseudo-class selectors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownPseudoElement": {
+					"description": "Disallow unknown pseudo-element selectors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnknownTypeSelector": {
+					"description": "Disallow unknown type selectors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessEscapeInRegex": {
+					"description": "Disallow unnecessary escape sequence in regular expression literals.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessStringRaw": {
+					"description": "Disallow unnecessary String.raw function in template string literals without any escape sequence.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noValueAtRule": {
+					"description": "Disallow use of @value rule in css modules.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useAdjacentOverloadSignatures": {
+					"description": "Disallow the use of overload signatures that are not next to each other.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useAriaPropsSupportedByRole": {
+					"description": "Enforce that ARIA properties are valid for the roles that are supported by the element.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useAtIndex": {
+					"description": "Use at() instead of integer index access.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useCollapsedIf": {
+					"description": "Enforce using single if instead of nested if clauses.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useComponentExportOnlyModules": {
+					"description": "Enforce declaring components only within modules that export React Components exclusively.",
+					"anyOf": [
+						{
+							"$ref": "#/definitions/UseComponentExportOnlyModulesConfiguration"
+						},
+						{ "type": "null" }
+					]
+				},
+				"useConsistentCurlyBraces": {
+					"description": "This rule enforces consistent use of curly braces inside JSX attributes and JSX children.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useConsistentMemberAccessibility": {
+					"description": "Require consistent accessibility modifiers on class properties and methods.",
+					"anyOf": [
+						{
+							"$ref": "#/definitions/ConsistentMemberAccessibilityConfiguration"
+						},
+						{ "type": "null" }
+					]
+				},
+				"useDeprecatedReason": {
+					"description": "Require specifying the reason argument when using @deprecated directive",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useExplicitType": {
+					"description": "Require explicit return types on functions and class methods.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useGoogleFontDisplay": {
+					"description": "Enforces the use of a recommended display strategy with Google Fonts.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useGuardForIn": {
+					"description": "Require for-in loops to include an if statement.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useImportRestrictions": {
+					"description": "Disallows package private imports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSortedClasses": {
+					"description": "Enforce the sorting of CSS utility classes.",
+					"anyOf": [
+						{ "$ref": "#/definitions/UtilityClassSortingConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useStrictMode": {
+					"description": "Enforce the use of the directive \"use strict\" in script files.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useTrimStartEnd": {
+					"description": "Enforce the use of String.trimStart() and String.trimEnd() over String.trimLeft() and String.trimRight().",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidAutocomplete": {
+					"description": "Use valid values for the autocomplete attribute on input elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/UseValidAutocompleteConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"OrganizeImports": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Enables the organization of imports",
+					"type": ["boolean", "null"]
+				},
+				"ignore": {
+					"description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"include": {
+					"description": "A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"OverrideFormatterConfiguration": {
+			"type": "object",
+			"properties": {
+				"attributePosition": {
+					"description": "The attribute position style.",
+					"anyOf": [
+						{ "$ref": "#/definitions/AttributePosition" },
+						{ "type": "null" }
+					]
+				},
+				"bracketSpacing": {
+					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSpacing" },
+						{ "type": "null" }
+					]
+				},
+				"enabled": { "type": ["boolean", "null"] },
+				"formatWithErrors": {
+					"description": "Stores whether formatting should be allowed to proceed if a given file has syntax errors",
+					"type": ["boolean", "null"]
+				},
+				"indentSize": {
+					"description": "The size of the indentation, 2 by default (deprecated, use `indent-width`)",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"indentStyle": {
+					"description": "The indent style.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation, 2 by default",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"OverrideLinterConfiguration": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "if `false`, it disables the feature and the linter won't be executed. `true` by default",
+					"type": ["boolean", "null"]
+				},
+				"rules": {
+					"description": "List of rules",
+					"anyOf": [{ "$ref": "#/definitions/Rules" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"OverrideOrganizeImportsConfiguration": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "if `false`, it disables the feature and the linter won't be executed. `true` by default",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"OverridePattern": {
+			"type": "object",
+			"properties": {
+				"css": {
+					"description": "Specific configuration for the Css language",
+					"anyOf": [
+						{ "$ref": "#/definitions/CssConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"formatter": {
+					"description": "Specific configuration for the Json language",
+					"anyOf": [
+						{ "$ref": "#/definitions/OverrideFormatterConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"graphql": {
+					"description": "Specific configuration for the Graphql language",
+					"anyOf": [
+						{ "$ref": "#/definitions/GraphqlConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"ignore": {
+					"description": "A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"include": {
+					"description": "A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.",
+					"anyOf": [{ "$ref": "#/definitions/StringSet" }, { "type": "null" }]
+				},
+				"javascript": {
+					"description": "Specific configuration for the JavaScript language",
+					"anyOf": [
+						{ "$ref": "#/definitions/JavascriptConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"json": {
+					"description": "Specific configuration for the Json language",
+					"anyOf": [
+						{ "$ref": "#/definitions/JsonConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"linter": {
+					"description": "Specific configuration for the Json language",
+					"anyOf": [
+						{ "$ref": "#/definitions/OverrideLinterConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"organizeImports": {
+					"description": "Specific configuration for the Json language",
+					"anyOf": [
+						{ "$ref": "#/definitions/OverrideOrganizeImportsConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Overrides": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/OverridePattern" }
+		},
+		"Performance": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noAccumulatingSpread": {
+					"description": "Disallow the use of spread (...) syntax on accumulators.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noBarrelFile": {
+					"description": "Disallow the use of barrel file.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDelete": {
+					"description": "Disallow the use of the delete operator.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noReExportAll": {
+					"description": "Avoid re-export all.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useTopLevelRegex": {
+					"description": "Require regex literals to be declared at the top level.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"QuoteProperties": { "type": "string", "enum": ["asNeeded", "preserve"] },
+		"QuoteStyle": { "type": "string", "enum": ["double", "single"] },
+		"Regex": { "type": "string" },
+		"RestrictedGlobalsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithRestrictedGlobalsOptions" }
+			]
+		},
+		"RestrictedGlobalsOptions": {
+			"description": "Options for the rule `noRestrictedGlobals`.",
+			"type": "object",
+			"properties": {
+				"deniedGlobals": {
+					"description": "A list of names that should trigger the rule",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"RestrictedImportsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithRestrictedImportsOptions" }
+			]
+		},
+		"RestrictedImportsOptions": {
+			"description": "Options for the rule `noRestrictedImports`.",
+			"type": "object",
+			"properties": {
+				"paths": {
+					"description": "A list of names that should trigger the rule",
+					"type": "object",
+					"additionalProperties": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"RestrictedModifier": {
+			"type": "string",
+			"enum": ["abstract", "private", "protected", "readonly", "static"]
+		},
+		"RuleAssistConfiguration": { "type": "string", "enum": ["on", "off"] },
+		"RuleConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoOptions" }
+			]
+		},
+		"RuleFixConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithFixNoOptions" }
+			]
+		},
+		"RulePlainConfiguration": {
+			"type": "string",
+			"enum": ["warn", "error", "info", "off"]
+		},
+		"RuleWithAllowDomainOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/AllowDomainOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithComplexityOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/ComplexityOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithConsistentArrayTypeOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/ConsistentArrayTypeOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithConsistentMemberAccessibilityOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [
+						{ "$ref": "#/definitions/ConsistentMemberAccessibilityOptions" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithDeprecatedHooksOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/DeprecatedHooksOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithFilenamingConventionOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/FilenamingConventionOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithFixNoOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNamingConventionOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NamingConventionOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoConsoleOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoConsoleOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoDoubleEqualsOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoDoubleEqualsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoLabelWithoutControlOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoLabelWithoutControlOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoRestrictedTypesOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoRestrictedTypesOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoSecretsOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoSecretsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithRestrictedGlobalsOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/RestrictedGlobalsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithRestrictedImportsOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/RestrictedImportsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithUseComponentExportOnlyModulesOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [
+						{ "$ref": "#/definitions/UseComponentExportOnlyModulesOptions" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithUseExhaustiveDependenciesOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [
+						{ "$ref": "#/definitions/UseExhaustiveDependenciesOptions" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithUseImportExtensionsOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/UseImportExtensionsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithUseValidAutocompleteOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/UseValidAutocompleteOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithUtilityClassSortingOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/UtilityClassSortingOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithValidAriaRoleOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/ValidAriaRoleOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Rules": {
+			"type": "object",
+			"properties": {
+				"a11y": {
+					"anyOf": [{ "$ref": "#/definitions/A11y" }, { "type": "null" }]
+				},
+				"all": {
+					"description": "It enables ALL rules. The rules that belong to `nursery` won't be enabled.",
+					"type": ["boolean", "null"]
+				},
+				"complexity": {
+					"anyOf": [{ "$ref": "#/definitions/Complexity" }, { "type": "null" }]
+				},
+				"correctness": {
+					"anyOf": [{ "$ref": "#/definitions/Correctness" }, { "type": "null" }]
+				},
+				"nursery": {
+					"anyOf": [{ "$ref": "#/definitions/Nursery" }, { "type": "null" }]
+				},
+				"performance": {
+					"anyOf": [{ "$ref": "#/definitions/Performance" }, { "type": "null" }]
+				},
+				"recommended": {
+					"description": "It enables the lint rules recommended by Biome. `true` by default.",
+					"type": ["boolean", "null"]
+				},
+				"security": {
+					"anyOf": [{ "$ref": "#/definitions/Security" }, { "type": "null" }]
+				},
+				"style": {
+					"anyOf": [{ "$ref": "#/definitions/Style" }, { "type": "null" }]
+				},
+				"suspicious": {
+					"anyOf": [{ "$ref": "#/definitions/Suspicious" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Scope": { "type": "string", "enum": ["any", "global"] },
+		"Security": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noDangerouslySetInnerHtml": {
+					"description": "Prevent the usage of dangerous JSX props",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDangerouslySetInnerHtmlWithChildren": {
+					"description": "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noGlobalEval": {
+					"description": "Disallow the use of global eval().",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Selector": {
+			"type": "object",
+			"properties": {
+				"kind": {
+					"description": "Declaration kind",
+					"allOf": [{ "$ref": "#/definitions/Kind" }]
+				},
+				"modifiers": {
+					"description": "Modifiers used on the declaration",
+					"allOf": [{ "$ref": "#/definitions/Modifiers" }]
+				},
+				"scope": {
+					"description": "Scope of the declaration",
+					"allOf": [{ "$ref": "#/definitions/Scope" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"Semicolons": { "type": "string", "enum": ["always", "asNeeded"] },
+		"Source": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"sortJsxProps": {
+					"description": "Enforce props sorting in JSX elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleAssistConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSortedKeys": {
+					"description": "Sorts the keys of a JSON object in natural order",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleAssistConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"StableHookResult": {
+			"oneOf": [
+				{
+					"description": "Whether the hook has a stable result.",
+					"type": "boolean"
+				},
+				{
+					"description": "Used to indicate the hook returns an array and some of its indices have stable identities.",
+					"type": "array",
+					"items": {
+						"type": "integer",
+						"format": "uint8",
+						"maximum": 255.0,
+						"minimum": 0.0
+					},
+					"minItems": 1
+				}
+			]
+		},
+		"StringSet": {
+			"type": "array",
+			"items": { "type": "string" },
+			"uniqueItems": true
+		},
+		"Style": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noArguments": {
+					"description": "Disallow the use of arguments.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noCommaOperator": {
+					"description": "Disallow comma operator.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDefaultExport": {
+					"description": "Disallow default exports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDoneCallback": {
+					"description": "Disallow using a callback in asynchronous tests and hooks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noImplicitBoolean": {
+					"description": "Disallow implicit true values on JSX boolean attributes",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noInferrableTypes": {
+					"description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNamespace": {
+					"description": "Disallow the use of TypeScript's namespaces.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNamespaceImport": {
+					"description": "Disallow the use of namespace imports.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNegationElse": {
+					"description": "Disallow negation in the condition of an if statement if it has an else clause.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noNonNullAssertion": {
+					"description": "Disallow non-null assertions using the ! postfix operator.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noParameterAssign": {
+					"description": "Disallow reassigning function parameters.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noParameterProperties": {
+					"description": "Disallow the use of parameter properties in class constructors.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRestrictedGlobals": {
+					"description": "This rule allows you to specify global variable names that you don’t want to use in your application.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RestrictedGlobalsConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noShoutyConstants": {
+					"description": "Disallow the use of constants which its value is the upper-case version of its name.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnusedTemplateLiteral": {
+					"description": "Disallow template literals if interpolation and special-character handling are not needed",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUselessElse": {
+					"description": "Disallow else block when the if block breaks early.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noVar": {
+					"description": "Disallow the use of var",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noYodaExpression": {
+					"description": "Disallow the use of yoda expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useAsConstAssertion": {
+					"description": "Enforce the use of as const over literal type and type annotation.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useBlockStatements": {
+					"description": "Requires following curly brace conventions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useCollapsedElseIf": {
+					"description": "Enforce using else if instead of nested if in else clauses.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useConsistentArrayType": {
+					"description": "Require consistently using either T\\[] or Array\\<T>",
+					"anyOf": [
+						{ "$ref": "#/definitions/ConsistentArrayTypeConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useConsistentBuiltinInstantiation": {
+					"description": "Enforce the use of new for all builtins, except String, Number and Boolean.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useConst": {
+					"description": "Require const declarations for variables that are only assigned once.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useDefaultParameterLast": {
+					"description": "Enforce default function parameters and optional function parameters to be last.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useDefaultSwitchClause": {
+					"description": "Require the default clause in switch statements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useEnumInitializers": {
+					"description": "Require that each enum member value be explicitly initialized.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useExplicitLengthCheck": {
+					"description": "Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useExponentiationOperator": {
+					"description": "Disallow the use of Math.pow in favor of the ** operator.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useExportType": {
+					"description": "Promotes the use of export type for types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useFilenamingConvention": {
+					"description": "Enforce naming conventions for JavaScript and TypeScript filenames.",
+					"anyOf": [
+						{ "$ref": "#/definitions/FilenamingConventionConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useForOf": {
+					"description": "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useFragmentSyntax": {
+					"description": "This rule enforces the use of \\<>...\\</> over \\<Fragment>...\\</Fragment>.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useImportType": {
+					"description": "Promotes the use of import type for types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useLiteralEnumMembers": {
+					"description": "Require all enum members to be literal values.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNamingConvention": {
+					"description": "Enforce naming conventions for everything across a codebase.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NamingConventionConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNodeAssertStrict": {
+					"description": "Promotes the usage of node:assert/strict over node:assert.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNodejsImportProtocol": {
+					"description": "Enforces using the node: protocol for Node.js builtin modules.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNumberNamespace": {
+					"description": "Use the Number properties instead of global ones.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNumericLiterals": {
+					"description": "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSelfClosingElements": {
+					"description": "Prevent extra closing tags for components without children",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useShorthandArrayType": {
+					"description": "When expressing array types, this rule promotes the usage of T\\[] shorthand instead of Array\\<T>.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useShorthandAssign": {
+					"description": "Require assignment operator shorthand where possible.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useShorthandFunctionType": {
+					"description": "Enforce using function types instead of object type with call signatures.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSingleCaseStatement": {
+					"description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useSingleVarDeclarator": {
+					"description": "Disallow multiple variable declarations in the same variable statement",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useTemplate": {
+					"description": "Prefer template literals over string concatenation.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useThrowNewError": {
+					"description": "Require new when throwing an error.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useThrowOnlyError": {
+					"description": "Disallow throwing non-Error values.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useWhile": {
+					"description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"SuggestedExtensionMapping": {
+			"type": "object",
+			"properties": {
+				"component": {
+					"description": "Extension that should be used for component file imports",
+					"default": "",
+					"type": "string"
+				},
+				"module": {
+					"description": "Extension that should be used for module imports",
+					"default": "",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"Suspicious": {
+			"description": "A list of rules that belong to this group",
+			"type": "object",
+			"properties": {
+				"all": {
+					"description": "It enables ALL rules for this group.",
+					"type": ["boolean", "null"]
+				},
+				"noApproximativeNumericConstant": {
+					"description": "Use standard constants instead of approximated literals.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noArrayIndexKey": {
+					"description": "Discourage the usage of Array index in keys.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noAssignInExpressions": {
+					"description": "Disallow assignments in expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noAsyncPromiseExecutor": {
+					"description": "Disallows using an async function as a Promise executor.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noCatchAssign": {
+					"description": "Disallow reassigning exceptions in catch clauses.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noClassAssign": {
+					"description": "Disallow reassigning class members.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noCommentText": {
+					"description": "Prevent comments from being inserted as text nodes",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noCompareNegZero": {
+					"description": "Disallow comparing against -0",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConfusingLabels": {
+					"description": "Disallow labeled statements that are not loops.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConfusingVoidType": {
+					"description": "Disallow void type outside of generic or return types.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConsole": {
+					"description": "Disallow the use of console.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoConsoleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConsoleLog": {
+					"description": "Disallow the use of console.log",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noConstEnum": {
+					"description": "Disallow TypeScript const enum",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noControlCharactersInRegex": {
+					"description": "Prevents from having control characters and some escape sequences that match control characters in regular expressions.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDebugger": {
+					"description": "Disallow the use of debugger",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDoubleEquals": {
+					"description": "Require the use of === and !==.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoDoubleEqualsConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateAtImportRules": {
+					"description": "Disallow duplicate @import rules.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateCase": {
+					"description": "Disallow duplicate case labels.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateClassMembers": {
+					"description": "Disallow duplicate class members.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateFontNames": {
+					"description": "Disallow duplicate names within font families.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateJsxProps": {
+					"description": "Prevents JSX properties to be assigned multiple times.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateObjectKeys": {
+					"description": "Disallow two keys with the same name inside objects.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateParameters": {
+					"description": "Disallow duplicate function parameter name.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateSelectorsKeyframeBlock": {
+					"description": "Disallow duplicate selectors within keyframe blocks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noDuplicateTestHooks": {
+					"description": "A describe block should not contain duplicate hooks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEmptyBlock": {
+					"description": "Disallow CSS empty blocks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEmptyBlockStatements": {
+					"description": "Disallow empty block statements and static blocks.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEmptyInterface": {
+					"description": "Disallow the declaration of empty interfaces.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noEvolvingTypes": {
+					"description": "Disallow variables from evolving into any type through reassignments.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExplicitAny": {
+					"description": "Disallow the any type usage.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExportsInTest": {
+					"description": "Disallow using export or module.exports in files containing tests",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noExtraNonNullAssertion": {
+					"description": "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noFallthroughSwitchClause": {
+					"description": "Disallow fallthrough of switch clauses.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noFocusedTests": {
+					"description": "Disallow focused tests.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noFunctionAssign": {
+					"description": "Disallow reassigning function declarations.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noGlobalAssign": {
+					"description": "Disallow assignments to native objects and read-only global variables.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noGlobalIsFinite": {
+					"description": "Use Number.isFinite instead of global isFinite.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noGlobalIsNan": {
+					"description": "Use Number.isNaN instead of global isNaN.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noImplicitAnyLet": {
+					"description": "Disallow use of implicit any type on variable declarations.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noImportAssign": {
+					"description": "Disallow assigning to imported bindings",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noImportantInKeyframe": {
+					"description": "Disallow invalid !important within keyframe declarations",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noLabelVar": {
+					"description": "Disallow labels that share a name with a variable",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMisleadingCharacterClass": {
+					"description": "Disallow characters made with multiple code points in character class syntax.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMisleadingInstantiator": {
+					"description": "Enforce proper usage of new and constructor.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMisplacedAssertion": {
+					"description": "Checks that the assertion function, for example expect, is placed inside an it() function call.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noMisrefactoredShorthandAssign": {
+					"description": "Disallow shorthand assign when variable appears on both sides.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noPrototypeBuiltins": {
+					"description": "Disallow direct use of Object.prototype builtins.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noReactSpecificProps": {
+					"description": "Prevents React-specific JSX properties from being used.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRedeclare": {
+					"description": "Disallow variable, function, class, and type redeclarations in the same scope.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noRedundantUseStrict": {
+					"description": "Prevents from having redundant \"use strict\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSelfCompare": {
+					"description": "Disallow comparisons where both sides are exactly the same.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noShadowRestrictedNames": {
+					"description": "Disallow identifiers from shadowing restricted names.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noShorthandPropertyOverrides": {
+					"description": "Disallow shorthand properties that override related longhand properties.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSkippedTests": {
+					"description": "Disallow disabled tests.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSparseArray": {
+					"description": "Disallow sparse arrays",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noSuspiciousSemicolonInJsx": {
+					"description": "It detects possible \"wrong\" semicolons inside JSX elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noThenProperty": {
+					"description": "Disallow then property.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnsafeDeclarationMerging": {
+					"description": "Disallow unsafe declaration merging between interfaces and classes.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noUnsafeNegation": {
+					"description": "Disallow using unsafe negation.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"recommended": {
+					"description": "It enables the recommended rules for this group",
+					"type": ["boolean", "null"]
+				},
+				"useAwait": {
+					"description": "Ensure async functions utilize await.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useDefaultSwitchClauseLast": {
+					"description": "Enforce default clauses in switch statements to be last",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useErrorMessage": {
+					"description": "Enforce passing a message value when creating a built-in error.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useGetterReturn": {
+					"description": "Enforce get methods to always return a value.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useIsArray": {
+					"description": "Use Array.isArray() instead of instanceof Array.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNamespaceKeyword": {
+					"description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useNumberToFixedDigitsArgument": {
+					"description": "Enforce using the digits argument with Number#toFixed().",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"useValidTypeof": {
+					"description": "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"TrailingCommas": {
+			"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.",
+			"oneOf": [
+				{
+					"description": "Trailing commas wherever possible (including function parameters and calls).",
+					"type": "string",
+					"enum": ["all"]
+				},
+				{
+					"description": "Trailing commas where valid in ES5 (objects, arrays, etc.). No trailing commas in type parameters in TypeScript.",
+					"type": "string",
+					"enum": ["es5"]
+				},
+				{
+					"description": "No trailing commas.",
+					"type": "string",
+					"enum": ["none"]
+				}
+			]
+		},
+		"TrailingCommas2": {
+			"oneOf": [
+				{
+					"description": "The formatter will remove the trailing commas",
+					"type": "string",
+					"enum": ["none"]
+				},
+				{
+					"description": "The trailing commas are allowed and advised",
+					"type": "string",
+					"enum": ["all"]
+				}
+			]
+		},
+		"UseComponentExportOnlyModulesConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUseComponentExportOnlyModulesOptions" }
+			]
+		},
+		"UseComponentExportOnlyModulesOptions": {
+			"type": "object",
+			"properties": {
+				"allowConstantExport": {
+					"description": "Allows the export of constants. This option is for environments that support it, such as [Vite](https://vitejs.dev/)",
+					"default": false,
+					"type": "boolean"
+				},
+				"allowExportNames": {
+					"description": "A list of names that can be additionally exported from the module This option is for exports that do not hinder [React Fast Refresh](https://github.com/facebook/react/tree/main/packages/react-refresh), such as [`meta` in Remix](https://remix.run/docs/en/main/route/meta)",
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"UseExhaustiveDependenciesConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUseExhaustiveDependenciesOptions" }
+			]
+		},
+		"UseExhaustiveDependenciesOptions": {
+			"description": "Options for the rule `useExhaustiveDependencies`",
+			"type": "object",
+			"properties": {
+				"hooks": {
+					"description": "List of hooks of which the dependencies should be validated.",
+					"default": [],
+					"type": "array",
+					"items": { "$ref": "#/definitions/Hook" }
+				},
+				"reportMissingDependenciesArray": {
+					"description": "Whether to report an error when a hook has no dependencies array.",
+					"default": false,
+					"type": "boolean"
+				},
+				"reportUnnecessaryDependencies": {
+					"description": "Whether to report an error when a dependency is listed in the dependencies array but isn't used. Defaults to true.",
+					"default": true,
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"UseImportExtensionsConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUseImportExtensionsOptions" }
+			]
+		},
+		"UseImportExtensionsOptions": {
+			"type": "object",
+			"properties": {
+				"suggestedExtensions": {
+					"description": "A map of custom import extension mappings, where the key is the inspected file extension, and the value is a pair of `module` extension and `component` import extension",
+					"default": {},
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/SuggestedExtensionMapping"
+					}
+				}
+			},
+			"additionalProperties": false
+		},
+		"UseValidAutocompleteConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUseValidAutocompleteOptions" }
+			]
+		},
+		"UseValidAutocompleteOptions": {
+			"type": "object",
+			"properties": {
+				"inputComponents": {
+					"description": "`input` like custom components that should be checked.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"UtilityClassSortingConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUtilityClassSortingOptions" }
+			]
+		},
+		"UtilityClassSortingOptions": {
+			"type": "object",
+			"properties": {
+				"attributes": {
+					"description": "Additional attributes that will be sorted.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				},
+				"functions": {
+					"description": "Names of the functions or tagged templates that will be sorted.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
+		"ValidAriaRoleConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithValidAriaRoleOptions" }
+			]
+		},
+		"ValidAriaRoleOptions": {
+			"type": "object",
+			"properties": {
+				"allowInvalidRoles": {
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"ignoreNonDom": { "default": false, "type": "boolean" }
+			},
+			"additionalProperties": false
+		},
+		"VcsClientKind": {
+			"oneOf": [
+				{
+					"description": "Integration with the git client as VCS",
+					"type": "string",
+					"enum": ["git"]
+				}
+			]
+		},
+		"VcsConfiguration": {
+			"description": "Set of properties to integrate Biome with a VCS software.",
+			"type": "object",
+			"properties": {
+				"clientKind": {
+					"description": "The kind of client.",
+					"anyOf": [
+						{ "$ref": "#/definitions/VcsClientKind" },
+						{ "type": "null" }
+					]
+				},
+				"defaultBranch": {
+					"description": "The main branch of the project",
+					"type": ["string", "null"]
+				},
+				"enabled": {
+					"description": "Whether Biome should integrate itself with the VCS client",
+					"type": ["boolean", "null"]
+				},
+				"root": {
+					"description": "The folder where Biome should check for VCS files. By default, Biome will use the same folder where `biome.json` was found.\n\nIf Biome can't find the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Biome won't use the VCS integration, and a diagnostic will be emitted",
+					"type": ["string", "null"]
+				},
+				"useIgnoreFile": {
+					"description": "Whether Biome should use the VCS ignore file. When [true], Biome will ignore the files specified in the ignore file.",
+					"type": ["boolean", "null"]
+				}
+			},
+			"additionalProperties": false
+		}
+	}
+}

--- a/node_modules/@biomejs/biome/package.json
+++ b/node_modules/@biomejs/biome/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@biomejs/biome",
+  "version": "1.9.4",
+  "bin": {
+    "biome": "bin/biome"
+  },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "homepage": "https://biomejs.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/biome"
+  },
+  "author": "Emanuele Stoppa",
+  "license": "MIT OR Apache-2.0",
+  "bugs": "https://github.com/biomejs/biome/issues",
+  "description": "Biome is a toolchain for the web: formatter, linter and more",
+  "files": [
+    "bin/biome",
+    "scripts/postinstall.js",
+    "configuration_schema.json",
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "ROME-LICENSE-MIT"
+  ],
+  "keywords": [
+    "format",
+    "lint",
+    "toolchain",
+    "JavaScript",
+    "TypeScript",
+    "JSON",
+    "JSONC",
+    "JSX",
+    "TSX",
+    "CSS",
+    "GraphQL"
+  ],
+  "engines": {
+    "node": ">=14.21.3"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/biome"
+  },
+  "publishConfig": {
+    "provenance": true
+  },
+  "optionalDependencies": {
+    "@biomejs/cli-win32-x64": "1.9.4",
+    "@biomejs/cli-win32-arm64": "1.9.4",
+    "@biomejs/cli-darwin-x64": "1.9.4",
+    "@biomejs/cli-darwin-arm64": "1.9.4",
+    "@biomejs/cli-linux-x64": "1.9.4",
+    "@biomejs/cli-linux-arm64": "1.9.4",
+    "@biomejs/cli-linux-x64-musl": "1.9.4",
+    "@biomejs/cli-linux-arm64-musl": "1.9.4"
+  }
+}

--- a/node_modules/@biomejs/biome/scripts/postinstall.js
+++ b/node_modules/@biomejs/biome/scripts/postinstall.js
@@ -1,0 +1,59 @@
+const { platform, arch } = process;
+// biome-ignore lint/style/useNodejsImportProtocol: would be a breaking change, consider bumping node version next major version
+const { execSync } = require("child_process");
+
+function isMusl() {
+	let stderr;
+	try {
+		stderr = execSync("ldd --version", {
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+	} catch (err) {
+		stderr = err.stderr;
+	}
+	if (stderr.indexOf("musl") > -1) {
+		return true;
+	}
+	return false;
+}
+
+const PLATFORMS = {
+	win32: {
+		x64: "@biomejs/cli-win32-x64/biome.exe",
+		arm64: "@biomejs/cli-win32-arm64/biome.exe",
+	},
+	darwin: {
+		x64: "@biomejs/cli-darwin-x64/biome",
+		arm64: "@biomejs/cli-darwin-arm64/biome",
+	},
+	linux: {
+		x64: "@biomejs/cli-linux-x64/biome",
+		arm64: "@biomejs/cli-linux-arm64/biome",
+	},
+	"linux-musl": {
+		x64: "@biomejs/cli-linux-x64-musl/biome",
+		arm64: "@biomejs/cli-linux-arm64-musl/biome",
+	},
+};
+
+const binName =
+	platform === "linux" && isMusl()
+		? PLATFORMS?.["linux-musl"]?.[arch]
+		: PLATFORMS?.[platform]?.[arch];
+
+if (binName) {
+	let binPath;
+	try {
+		binPath = require.resolve(binName);
+	} catch {
+		console.warn(
+			`The Biome CLI postinstall script failed to resolve the binary file "${binName}". Running Biome from the npm package will probably not work correctly.`,
+		);
+	}
+} else {
+	console.warn(
+		"The Biome CLI package doesn't ship with prebuilt binaries for your platform yet. " +
+			"You can still use the CLI by cloning the biomejs/biome repo from GitHub, " +
+			"and follow the instructions there to build the CLI for your platform.",
+	);
+}

--- a/node_modules/@biomejs/cli-win32-x64/package.json
+++ b/node_modules/@biomejs/cli-win32-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@biomejs/cli-win32-x64",
+  "version": "1.9.4",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/biome"
+  },
+  "engines": {
+    "node": ">=14.21.3"
+  },
+  "homepage": "https://biomejs.dev",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,176 @@
+{
+  "name": "cinema-reservation-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@biomejs/biome": "1.9.4"
+  }
+}


### PR DESCRIPTION
## 概要

Biomeを導入して、各ファイルのフォーマットやルールの統一化。

## 変更の背景

- チーム開発時にそれぞれの個性が統一されるようにする
- PR時のファイルチェンジに不要な変更が含まれないこと

## 変更内容

Biomeをインストール
ルートディレクトリに`biome.json`を作成して、基本的なフォーマットを設定。
※今後、チームで協議して変更の可能性あり。

## 動作確認

- [x] console.logや未使用のインポートがある場合エラーが出ること
- [x] 上記のエラーが保存時に訂正されること  

## 関連する課題/チケット

closes #1 

## 参考文献

[ESLint + Prettierの代わりにBiomeを試す](https://qiita.com/99no_exit/items/4b880735621d7f7416f3)
